### PR TITLE
Added argument sendTreeHasChanged=true to TreeViewItem::removeSubItem

### DIFF
--- a/modules/juce_gui_basics/widgets/juce_TreeView.cpp
+++ b/modules/juce_gui_basics/widgets/juce_TreeView.cpp
@@ -1226,13 +1226,13 @@ void TreeViewItem::addSubItem (TreeViewItem* const newItem, const int insertPosi
     }
 }
 
-void TreeViewItem::removeSubItem (int index, bool deleteItem)
+void TreeViewItem::removeSubItem (int index, bool deleteItem, bool sendTreeHasChanged)
 {
     if (ownerView != nullptr)
     {
         const ScopedLock sl (ownerView->nodeAlterationLock);
 
-        if (removeSubItemFromList (index, deleteItem))
+        if (removeSubItemFromList (index, deleteItem) && sendTreeHasChanged)
             treeHasChanged();
     }
     else

--- a/modules/juce_gui_basics/widgets/juce_TreeView.h
+++ b/modules/juce_gui_basics/widgets/juce_TreeView.h
@@ -102,7 +102,7 @@ public:
         @param index        the item to remove
         @param deleteItem   if true, the item that is removed will also be deleted.
     */
-    void removeSubItem (int index, bool deleteItem = true);
+    void removeSubItem (int index, bool deleteItem = true, bool sendTreeHasChanged = true);
 
     /** Sorts the list of sub-items using a standard array comparator.
 


### PR DESCRIPTION
It may be desirable to delay refreshing and repainting the TreeView. In
particular, deadlocks can be caused by repainting the TreeView component
into an OpenGL context while it is active on the render thread.