### PR TITLE
Fixed missing install paths on OS X.

### DIFF
--- a/extras/Introjucer/JuceLibraryCode/BinaryData.cpp
+++ b/extras/Introjucer/JuceLibraryCode/BinaryData.cpp
@@ -1422,7 +1422,9 @@ static const unsigned char temp_binary_data_21[] =
 "\r\n"
 "if [ $copyAU -gt 0 ]; then\r\n"
 "  echo \"Copying to AudioUnit folder...\"\r\n"
-"  AU=~/Library/Audio/Plug-Ins/Components/$PRODUCT_NAME.component\r\n"
+"  AUDir=~/Library/Audio/Plug-Ins/Components\r\n"
+"  mkdir -p \"$AUDir\"\r\n"
+"  AU=$AUDir/$PRODUCT_NAME.component\r\n"
 "  if [ -d \"$AU\" ]; then \r\n"
 "    rm -r \"$AU\"\r\n"
 "  fi\r\n"
@@ -1442,7 +1444,9 @@ static const unsigned char temp_binary_data_21[] =
 "\r\n"
 "if [ $copyVST -gt 0 ]; then\r\n"
 "  echo \"Copying to VST folder...\"\r\n"
-"  VST=~/Library/Audio/Plug-Ins/VST/$PRODUCT_NAME.vst\r\n"
+"  VSTDir=~/Library/Audio/Plug-Ins/VST\r\n"
+"  mkdir -p \"$VSTDir\"\r\n"
+"  VST=$VSTDir/$PRODUCT_NAME.vst\r\n"
 "  if [ -d \"$VST\" ]; then \r\n"
 "    rm -r \"$VST\"\r\n"
 "  fi\r\n"
@@ -1454,7 +1458,9 @@ static const unsigned char temp_binary_data_21[] =
 "\r\n"
 "if [ $copyVST3 -gt 0 ]; then\r\n"
 "  echo \"Copying to VST3 folder...\"\r\n"
-"  VST3=~/Library/Audio/Plug-Ins/VST3/$PRODUCT_NAME.vst3\r\n"
+"  VST3Dir=~/Library/Audio/Plug-Ins/VST3\r\n"
+"  mkdir -p \"$VST3Dir\"\r\n"
+"  VST3=$VST3Dir/$PRODUCT_NAME.vst3\r\n"
 "  if [ -d \"$VST3\" ]; then \r\n"
 "    rm -r \"$VST3\"\r\n"
 "  fi\r\n"
@@ -1466,12 +1472,15 @@ static const unsigned char temp_binary_data_21[] =
 "\r\n"
 "if [ $copyRTAS -gt 0 ]; then\r\n"
 "  echo \"Copying to RTAS folder...\"\r\n"
-"  RTAS=/Library/Application\\ Support/Digidesign/Plug-Ins/$PRODUCT_NAME.dpm\r\n"
-"  if [ -d \"$RTAS\" ]; then\r\n"
-"    rm -r \"$RTAS\"\r\n"
-"  fi\r\n"
+"  RTASDir=/Library/Application\\ Support/Digidesign/Plug-Ins\r\n"
+"  if [ -d \"$RTASDir\" ]; then\r\n"
+"    RTAS=$RTASDir/$PRODUCT_NAME.dpm\r\n"
+"    if [ -d \"$RTAS\" ]; then\r\n"
+"      rm -r \"$RTAS\"\r\n"
+"    fi\r\n"
 "\r\n"
-"  cp -r \"$original\" \"$RTAS\"\r\n"
+"    cp -r \"$original\" \"$RTAS\"\r\n"
+"  fi\r\n"
 "fi\r\n"
 "\r\n"
 "if [ $copyAAX -gt 0 ]; then\r\n"
@@ -4096,7 +4105,7 @@ const char* getNamedResource (const char* resourceNameUTF8, int& numBytes) throw
         case 0x0842c43c:  numBytes = 308; return jucer_NewCppFileTemplate_h;
         case 0x36e634a1:  numBytes = 1626; return jucer_NewInlineComponentTemplate_h;
         case 0x7fbac252:  numBytes = 1827; return jucer_OpenGLComponentTemplate_cpp;
-        case 0x44be9398:  numBytes = 2922; return AudioPluginXCodeScript_txt;
+        case 0x44be9398:  numBytes = 3108; return AudioPluginXCodeScript_txt;
         case 0x4a0cfd09:  numBytes = 151; return background_tile_png;
         case 0x763d39dc:  numBytes = 1050; return colourscheme_dark_xml;
         case 0xe8b08520:  numBytes = 1050; return colourscheme_light_xml;

--- a/extras/Introjucer/JuceLibraryCode/BinaryData.h
+++ b/extras/Introjucer/JuceLibraryCode/BinaryData.h
@@ -73,7 +73,7 @@ namespace BinaryData
     const int            jucer_OpenGLComponentTemplate_cppSize = 1827;
 
     extern const char*   AudioPluginXCodeScript_txt;
-    const int            AudioPluginXCodeScript_txtSize = 2922;
+    const int            AudioPluginXCodeScript_txtSize = 3108;
 
     extern const char*   background_tile_png;
     const int            background_tile_pngSize = 151;

--- a/extras/Introjucer/Source/BinaryData/AudioPluginXCodeScript.txt
+++ b/extras/Introjucer/Source/BinaryData/AudioPluginXCodeScript.txt
@@ -13,7 +13,9 @@ copyAAX=`nm -g "$CONFIGURATION_BUILD_DIR/$EXECUTABLE_PATH" | grep -i 'ACFStartup
 
 if [ $copyAU -gt 0 ]; then
   echo "Copying to AudioUnit folder..."
-  AU=~/Library/Audio/Plug-Ins/Components/$PRODUCT_NAME.component
+  AUDir=~/Library/Audio/Plug-Ins/Components
+  mkdir -p "$AUDir"
+  AU=$AUDir/$PRODUCT_NAME.component
   if [ -d "$AU" ]; then 
     rm -r "$AU"
   fi
@@ -33,7 +35,9 @@ fi
 
 if [ $copyVST -gt 0 ]; then
   echo "Copying to VST folder..."
-  VST=~/Library/Audio/Plug-Ins/VST/$PRODUCT_NAME.vst
+  VSTDir=~/Library/Audio/Plug-Ins/VST
+  mkdir -p "$VSTDir"
+  VST=$VSTDir/$PRODUCT_NAME.vst
   if [ -d "$VST" ]; then 
     rm -r "$VST"
   fi
@@ -45,7 +49,9 @@ fi
 
 if [ $copyVST3 -gt 0 ]; then
   echo "Copying to VST3 folder..."
-  VST3=~/Library/Audio/Plug-Ins/VST3/$PRODUCT_NAME.vst3
+  VST3Dir=~/Library/Audio/Plug-Ins/VST3
+  mkdir -p "$VST3Dir"
+  VST3=$VST3Dir/$PRODUCT_NAME.vst3
   if [ -d "$VST3" ]; then 
     rm -r "$VST3"
   fi
@@ -57,12 +63,15 @@ fi
 
 if [ $copyRTAS -gt 0 ]; then
   echo "Copying to RTAS folder..."
-  RTAS=/Library/Application\ Support/Digidesign/Plug-Ins/$PRODUCT_NAME.dpm
-  if [ -d "$RTAS" ]; then
-    rm -r "$RTAS"
-  fi
+  RTASDir=/Library/Application\ Support/Digidesign/Plug-Ins
+  if [ -d "$RTASDir" ]; then
+    RTAS=$RTASDir/$PRODUCT_NAME.dpm
+    if [ -d "$RTAS" ]; then
+      rm -r "$RTAS"
+    fi
 
-  cp -r "$original" "$RTAS"
+    cp -r "$original" "$RTAS"
+  fi
 fi
 
 if [ $copyAAX -gt 0 ]; then


### PR DESCRIPTION
The final step of the build process on OS X produces errors if the install destinations don't already exist. This creates directories in ~/Library/Audio/Plug-Ins for AU, VST and VST3, and is more careful about RTAS.