### PR TITLE
Update juce_PopupMenu.cpp

### DIFF
--- a/modules/juce_gui_basics/menus/juce_PopupMenu.cpp
+++ b/modules/juce_gui_basics/menus/juce_PopupMenu.cpp
@@ -1698,23 +1698,26 @@ void PopupMenu::CustomComponent::setHighlighted (bool shouldBeHighlighted)
 
 void PopupMenu::CustomComponent::triggerMenuItem()
 {
-    if (HelperClasses::ItemComponent* const mic = dynamic_cast<HelperClasses::ItemComponent*> (getParentComponent()))
+    if (HelperClasses::NormalComponentWrapper* const pre = dynamic_cast<HelperClasses::NormalComponentWrapper*> (getParentComponent()))
     {
-        if (HelperClasses::MenuWindow* const pmw = dynamic_cast<HelperClasses::MenuWindow*> (mic->getParentComponent()))
+        if (HelperClasses::ItemComponent* const mic = dynamic_cast<HelperClasses::ItemComponent*> (pre->getParentComponent()))
         {
-            pmw->dismissMenu (&mic->itemInfo);
+            if (HelperClasses::MenuWindow* const pmw = dynamic_cast<HelperClasses::MenuWindow*> (mic->getParentComponent()))
+            {
+                pmw->dismissMenu (&mic->itemInfo);
+            }
+            else
+            {
+                // something must have gone wrong with the component hierarchy if this happens..
+                jassertfalse;
+            }
         }
         else
         {
-            // something must have gone wrong with the component hierarchy if this happens..
+            // why isn't this component inside a menu? Not much point triggering the item if
+            // there's no menu.
             jassertfalse;
         }
-    }
-    else
-    {
-        // why isn't this component inside a menu? Not much point triggering the item if
-        // there's no menu.
-        jassertfalse;
     }
 }
 


### PR DESCRIPTION
It seems that one parent level more is needed in order to reach dismissMenu method. It was tested on my project - Win32 & OSX x86 & x64

The Component parent hierachy is:
        this | [juce::PopupMenu::HelperClasses::NormalComponentWrapper] | [juce::PopupMenu::HelperClasses::ItemComponent] | [juce::PopupMenu::HelperClasses::MenuWindow]
 
Instead of:
        // this | [juce::PopupMenu::HelperClasses::ItemComponent] | [juce::PopupMenu::HelperClasses::MenuWindow] 
as the code pretends to find.


Ask for my example code to me if you want to double check.