### PR TITLE
Update juce_ComboBox.h

### DIFF
--- a/modules/juce_gui_basics/widgets/juce_ComboBox.h
+++ b/modules/juce_gui_basics/widgets/juce_ComboBox.h
@@ -414,7 +414,7 @@ public:
     JUCE_DEPRECATED (void setSelectedItemIndex (int, bool));
     JUCE_DEPRECATED (void setText (const String&, bool));
 
-private:
+protected:
     //==============================================================================
     struct ItemInfo
     {


### PR DESCRIPTION
This pull request is for allowing ComboBox subclasses. In particular, for obtaining "label" access. As an example:

void ComboCalendarComponent::showPopup(void)
{
    PopupMenu m;
    m.addCustomItem(1, &m_calendarItem, CalendarComponent::Default_Width, CalendarComponent::Default_Height, false);

    m.showMenuAsync (PopupMenu::Options().withTargetComponent (this)
                                         .withItemThatMustBeVisible (getSelectedId())
                                         .withMinimumWidth (getWidth())
                                         .withMaximumNumColumns (1)
                                         .withStandardItemHeight (ComboBox::label->getHeight()),
                                         ModalCallbackFunction::forComponent (popupMenuFinishedCallback, this));
}

Where "ComboCalendarComponent" is a ComboBox specialization