### PR TITLE
Fix shift-delete cut behavior in text editors

### DIFF
--- a/modules/juce_gui_basics/keyboard/juce_TextEditorKeyMapper.h
+++ b/modules/juce_gui_basics/keyboard/juce_TextEditorKeyMapper.h
@@ -88,7 +88,7 @@ struct TextEditorKeyMapper
         if (numCtrlAltCommandKeys < 2)
         {
             if (key.isKeyCode (KeyPress::backspaceKey)) return target.deleteBackwards (ctrlOrAltDown);
-            if (key.isKeyCode (KeyPress::deleteKey))    return target.deleteForwards  (ctrlOrAltDown);
+            if (!isShiftDown && key.isKeyCode (KeyPress::deleteKey))    return target.deleteForwards  (ctrlOrAltDown);
         }
 
         if (key == KeyPress ('c', ModifierKeys::commandModifier, 0)


### PR DESCRIPTION
Cut using shift-delete was broken in text fields due to delete taking precedence.