### PR TITLE
Fix compilation errors in MinGW

### DIFF
--- a/modules/juce_audio_basics/effects/juce_FFT.cpp
+++ b/modules/juce_audio_basics/effects/juce_FFT.cpp
@@ -22,6 +22,10 @@
   ==============================================================================
 */
 
+#if JUCE_MINGW
+ #define alloca __builtin_alloca
+#endif
+
 // (For the moment, we'll implement a few local operators for this complex class - one
 // day we'll probably either have a juce complex class, or use the C++11 one)
 static FFT::Complex operator+ (FFT::Complex a, FFT::Complex b) noexcept     { FFT::Complex c = { a.r + b.r, a.i + b.i }; return c; }

--- a/modules/juce_core/maths/juce_MathsFunctions.h
+++ b/modules/juce_core/maths/juce_MathsFunctions.h
@@ -376,7 +376,7 @@ bool juce_isfinite (NumericType) noexcept
 template <>
 inline bool juce_isfinite (float value) noexcept
 {
-   #if JUCE_WINDOWS
+   #if JUCE_WINDOWS && ! JUCE_MINGW
     return _finite (value) != 0;
    #else
     return std::isfinite (value);
@@ -386,7 +386,7 @@ inline bool juce_isfinite (float value) noexcept
 template <>
 inline bool juce_isfinite (double value) noexcept
 {
-   #if JUCE_WINDOWS
+   #if JUCE_WINDOWS && ! JUCE_MINGW
     return _finite (value) != 0;
    #else
     return std::isfinite (value);

--- a/modules/juce_core/text/juce_CharacterFunctions.h
+++ b/modules/juce_core/text/juce_CharacterFunctions.h
@@ -44,6 +44,10 @@
  #define JUCE_NATIVE_WCHAR_IS_UTF32     1
 #endif
 
+#if JUCE_MINGW
+ #include <sys/types.h>
+#endif
+
 #if JUCE_NATIVE_WCHAR_IS_UTF32 || DOXYGEN
  /** A platform-independent 32-bit unicode character type. */
  typedef wchar_t        juce_wchar;

--- a/modules/juce_core/text/juce_TextDiff.cpp
+++ b/modules/juce_core/text/juce_TextDiff.cpp
@@ -26,6 +26,10 @@
   ==============================================================================
 */
 
+#if JUCE_MINGW
+ #define alloca __builtin_alloca
+#endif
+
 struct TextDiffHelpers
 {
     enum { minLengthToMatch = 3,

--- a/modules/juce_core/time/juce_Time.cpp
+++ b/modules/juce_core/time/juce_Time.cpp
@@ -26,6 +26,10 @@
   ==============================================================================
 */
 
+#if JUCE_MINGW
+ #include <sys/time.h>
+#endif
+
 namespace TimeHelpers
 {
     static struct tm millisToLocal (const int64 millis) noexcept
@@ -65,10 +69,16 @@ namespace TimeHelpers
             time_t now = static_cast <time_t> (seconds);
 
            #if JUCE_WINDOWS
+            #if JUCE_MINGW
+              struct tm *timeinfo;
+              timeinfo = localtime(&now);
+              result = *timeinfo;
+            #else
             if (now >= 0 && now <= 0x793406fff)
                 localtime_s (&result, &now);
             else
                 zerostruct (result);
+            #endif
            #else
             localtime_r (&now, &result); // more thread-safe
            #endif
@@ -190,7 +200,7 @@ Time& Time::operator= (const Time& other) noexcept
 //==============================================================================
 int64 Time::currentTimeMillis() noexcept
 {
-   #if JUCE_WINDOWS
+   #if JUCE_WINDOWS && ! JUCE_MINGW
     struct _timeb t;
     _ftime_s (&t);
     return ((int64) t.time) * 1000 + t.millitm;


### PR DESCRIPTION
This PR should fix some compilation errors while building JUCE's modules with MinGW (GCC 4.8.1).