### PR TITLE
Introjucer xcode custom plist fix (disable retina display)

### DIFF
--- a/extras/Introjucer/Source/Utility/jucer_MiscUtilities.cpp
+++ b/extras/Introjucer/Source/Utility/jucer_MiscUtilities.cpp
@@ -206,12 +206,42 @@ void addPlistDictionaryKey (XmlElement* xml, const String& key, const String& va
 
 void addPlistDictionaryKeyBool (XmlElement* xml, const String& key, const bool value)
 {
+    forEachXmlChildElementWithTagName (*xml, e, "key")
+      {
+          if (e->getAllSubText().trim().equalsIgnoreCase (key))
+          {
+              if (e->getNextElement() != nullptr && e->getNextElement()->hasTagName ("key"))
+              {
+                  // try to fix broken plist format..
+                  xml->removeChildElement (e, true);
+                  break;
+              }
+  
+              return; // (value already exists)
+          }
+      }
+      
     xml->createNewChildElement ("key")->addTextElement (key);
     xml->createNewChildElement (value ? "true" : "false");
 }
 
 void addPlistDictionaryKeyInt (XmlElement* xml, const String& key, int value)
 {
+    forEachXmlChildElementWithTagName (*xml, e, "key")
+      {
+          if (e->getAllSubText().trim().equalsIgnoreCase (key))
+          {
+              if (e->getNextElement() != nullptr && e->getNextElement()->hasTagName ("key"))
+              {
+                  // try to fix broken plist format..
+                  xml->removeChildElement (e, true);
+                  break;
+              }
+  
+              return; // (value already exists)
+          }
+      }
+      
     xml->createNewChildElement ("key")->addTextElement (key);
     xml->createNewChildElement ("integer")->addTextElement (String (value));
 }

--- a/extras/Introjucer/Source/Utility/jucer_MiscUtilities.cpp
+++ b/extras/Introjucer/Source/Utility/jucer_MiscUtilities.cpp
@@ -207,19 +207,19 @@ void addPlistDictionaryKey (XmlElement* xml, const String& key, const String& va
 void addPlistDictionaryKeyBool (XmlElement* xml, const String& key, const bool value)
 {
     forEachXmlChildElementWithTagName (*xml, e, "key")
-      {
-          if (e->getAllSubText().trim().equalsIgnoreCase (key))
-          {
-              if (e->getNextElement() != nullptr && e->getNextElement()->hasTagName ("key"))
-              {
-                  // try to fix broken plist format..
-                  xml->removeChildElement (e, true);
-                  break;
-              }
-  
-              return; // (value already exists)
-          }
-      }
+    {
+        if (e->getAllSubText().trim().equalsIgnoreCase (key))
+        {
+            if (e->getNextElement() != nullptr && e->getNextElement()->hasTagName ("key"))
+            {
+                // try to fix broken plist format..
+                xml->removeChildElement (e, true);
+                break;
+            }
+
+            return; // (value already exists)
+        }
+    }
       
     xml->createNewChildElement ("key")->addTextElement (key);
     xml->createNewChildElement (value ? "true" : "false");
@@ -228,19 +228,19 @@ void addPlistDictionaryKeyBool (XmlElement* xml, const String& key, const bool v
 void addPlistDictionaryKeyInt (XmlElement* xml, const String& key, int value)
 {
     forEachXmlChildElementWithTagName (*xml, e, "key")
-      {
-          if (e->getAllSubText().trim().equalsIgnoreCase (key))
-          {
-              if (e->getNextElement() != nullptr && e->getNextElement()->hasTagName ("key"))
-              {
-                  // try to fix broken plist format..
-                  xml->removeChildElement (e, true);
-                  break;
-              }
-  
-              return; // (value already exists)
-          }
-      }
+    {
+        if (e->getAllSubText().trim().equalsIgnoreCase (key))
+        {
+            if (e->getNextElement() != nullptr && e->getNextElement()->hasTagName ("key"))
+            {
+                // try to fix broken plist format..
+                xml->removeChildElement (e, true);
+                break;
+            }
+
+            return; // (value already exists)
+        }
+    }
       
     xml->createNewChildElement ("key")->addTextElement (key);
     xml->createNewChildElement ("integer")->addTextElement (String (value));


### PR DESCRIPTION
Function 
```sh
Introjucer/Source/Utility/jucer_MiscUtilities.cpp/addPlistDictionaryKey()
```
checks for existing xml child key before adding a new key and skips in case the key already exists.
This enable merging of Introjucer generated info.plist with custom xml properties for Xcode projects.
The  "already existing key" check snippet was missing from addPlistDictionaryKeyBool and addPlistDictionaryKeyInt, resulting in errors when adding bool or int values to custom xml in Introjucer.

e.g. if you try to disable retina display by adding 
```sh
<key>NSHighResolutionCapable</key> <false/>
```
The NSHighResolutionCapable (being a bool value) is added twice to info.plist xml, one with false value, one with default true value.
This confuses Xcode that uses the last (default) true value, actually ignoring the custom plist and always enabling retina display.