### PR TITLE
StringArray, removeString corrections

### DIFF
--- a/modules/juce_core/text/juce_StringArray.cpp
+++ b/modules/juce_core/text/juce_StringArray.cpp
@@ -227,15 +227,21 @@ void StringArray::removeString (StringRef stringToRemove, const bool ignoreCase)
 {
     if (ignoreCase)
     {
-        for (int i = size(); --i >= 0;)
+        for (int i = 0; i < size(); i++)
             if (strings.getReference(i).equalsIgnoreCase (stringToRemove))
+            {
                 strings.remove (i);
+                break;
+            }
     }
     else
     {
-        for (int i = size(); --i >= 0;)
+        for (int i = 0; i < size(); i++)
             if (stringToRemove == strings.getReference (i))
+            {
                 strings.remove (i);
+                break;
+            }
     }
 }
 

--- a/modules/juce_core/text/juce_StringArray.cpp
+++ b/modules/juce_core/text/juce_StringArray.cpp
@@ -245,6 +245,22 @@ void StringArray::removeString (StringRef stringToRemove, const bool ignoreCase)
     }
 }
 
+void StringArray::removeAllOccurrencesOfString (StringRef stringToRemove, const bool ignoreCase)
+{
+    if (ignoreCase)
+    {
+        for (int i = size(); --i >= 0;)
+            if (strings.getReference(i).equalsIgnoreCase (stringToRemove))
+                strings.remove (i);
+    }
+    else
+    {
+        for (int i = size(); --i >= 0;)
+            if (stringToRemove == strings.getReference (i))
+                strings.remove (i);
+    }
+}
+
 void StringArray::removeRange (int startIndex, int numberToRemove)
 {
     strings.removeRange (startIndex, numberToRemove);

--- a/modules/juce_core/text/juce_StringArray.h
+++ b/modules/juce_core/text/juce_StringArray.h
@@ -304,9 +304,17 @@ public:
     /** Finds a string in the array and removes it.
         This will remove the first occurrence of the given string from the array. The
         comparison may be case-insensitive depending on the ignoreCase parameter.
+        @see removeAllOccurrencesOfString
     */
     void removeString (StringRef stringToRemove,
                        bool ignoreCase = false);
+
+    /** Finds a string in the array and removes every instance of it.
+        The comparison may be case-insensitive depending on the ignoreCase parameter.
+        @see removeString
+     */
+    void removeAllOccurrencesOfString (StringRef stringToRemove,
+                                       bool ignoreCase = false);
 
     /** Removes a range of elements from the array.
 


### PR DESCRIPTION
- StringArray::removeString was documented to remove the first occurrence of the given string, but actually removed every occurrence. Corrected this behaviour.

- Added a new removeAllOccurencesOfString method to restore the behaviour removeString was accidentally facilitating