### PR TITLE
Remove extra ';'

### DIFF
--- a/modules/juce_core/native/juce_linux_CommonFile.cpp
+++ b/modules/juce_core/native/juce_linux_CommonFile.cpp
@@ -63,7 +63,7 @@ static String getLinkedFile (const String& file)
     HeapBlock<char> buffer (8194);
     const int numBytes = (int) readlink (file.toRawUTF8(), buffer, 8192);
     return String::fromUTF8 (buffer, jmax (0, numBytes));
-};
+}
 
 bool File::isSymbolicLink() const
 {

--- a/modules/juce_gui_basics/layout/juce_AnimatedPositionBehaviours.h
+++ b/modules/juce_gui_basics/layout/juce_AnimatedPositionBehaviours.h
@@ -145,7 +145,7 @@ namespace AnimatedPositionBehaviours
     private:
         double targetSnapPosition;
     };
-};
+}
 
 
 #endif   // JUCE_ANIMATEDPOSITIONBEHAVIOURS_H_INCLUDED

--- a/modules/juce_gui_extra/code_editor/juce_XMLCodeTokeniser.cpp
+++ b/modules/juce_gui_extra/code_editor/juce_XMLCodeTokeniser.cpp
@@ -52,7 +52,7 @@ CodeEditorComponent::ColourScheme XmlTokeniser::getDefaultColourScheme()
         cs.set (types[i].name, Colour (types[i].colour));
 
     return cs;
-};
+}
 
 template <typename Iterator>
 static void skipToEndOfXmlDTD (Iterator& source) noexcept


### PR DESCRIPTION
I'm compiling a subset of JUCE modules for VST hosting purposes, with gcc version 5.3.1 on Linux (Debian stretch). This PR fixes warnings/errors about some extra semicolons here and there when JUCE modules are compiled with `-Wall -pedantic -Werror`.