### PR TITLE
fix typo in File class documentation

### DIFF
--- a/modules/juce_core/files/juce_File.h
+++ b/modules/juce_core/files/juce_File.h
@@ -48,7 +48,7 @@ public:
     //==============================================================================
     /** Creates an (invalid) file object.
 
-        The file is initially set to an empty path, so getFullPath() will return
+        The file is initially set to an empty path, so getFullPathName() will return
         an empty string, and comparing the file to File::nonexistent will return
         true.
 


### PR DESCRIPTION
the documentation for the File::File() constructor reads:

> "... so getFullPath() will return an empty string"

but there is no such method - prbably referring to getFullPathName() - yes?