### PR TITLE
Fix HAVE_STDLIB_H redefinition

### DIFF
--- a/modules/juce_graphics/image_formats/jpglib/jconfig.h
+++ b/modules/juce_graphics/image_formats/jpglib/jconfig.h
@@ -20,7 +20,9 @@
 /* #define const */
 #undef CHAR_IS_UNSIGNED
 #define HAVE_STDDEF_H
+#ifndef HAVE_STDLIB_H
 #define HAVE_STDLIB_H
+#endif
 #undef NEED_BSD_STRINGS
 #undef NEED_SYS_TYPES_H
 #undef NEED_FAR_POINTERS	/* we presume a 32-bit flat memory model */


### PR DESCRIPTION
This PR tries to fix a macro redefinition with GCC 5.3.1 on Debian testing (Linux), when compiled with `-Werror` flag.