### PR TITLE
MSVC compiler warning C4512 fixed

### DIFF
--- a/modules/juce_audio_plugin_client/utility/juce_PluginBusUtilities.h
+++ b/modules/juce_audio_plugin_client/utility/juce_PluginBusUtilities.h
@@ -27,6 +27,8 @@ struct PluginBusUtilities
 {
     //==============================================================================
     typedef Array<AudioProcessor::AudioProcessorBus> AudioBusArray;
+    
+    PluginBusUtilities& operator=(const PluginBusUtilities&) = delete; // To avoid "assignment operator could not be generated" compiler warning
 
     //==============================================================================
     PluginBusUtilities (AudioProcessor& plugin, bool markDiscreteLayoutsAsSupported)


### PR DESCRIPTION
MSVC warning C4512 "assignment operator could not be generated" fixed