### PR TITLE
don't call method on null object

### DIFF
--- a/modules/juce_events/native/juce_linux_Messaging.cpp
+++ b/modules/juce_events/native/juce_linux_Messaging.cpp
@@ -360,6 +360,8 @@ bool MessageManager::postMessageToSystemQueue (MessageManager::MessageBase* cons
     if (LinuxErrorHandling::errorOccurred)
         return false;
 
+    if (!InternalMessageQueue::getInstanceWithoutCreating())	return false;
+    
     InternalMessageQueue::getInstanceWithoutCreating()->postMessage (message);
     return true;
 }


### PR DESCRIPTION
don't post message to null msg manager, whose instantiation isn't immediate