### PR TITLE
Fix missing field initializer

### DIFF
--- a/modules/juce_gui_basics/drawables/juce_SVGParser.cpp
+++ b/modules/juce_gui_basics/drawables/juce_SVGParser.cpp
@@ -905,7 +905,7 @@ private:
                 }
             };
 
-            GetFillTypeOp op = { this, &path, opacity };
+            GetFillTypeOp op = { this, &path, opacity, {} };
 
             if (topLevelXml.applyOperationToChildWithID (urlID, op))
                 return op.fillType;


### PR DESCRIPTION
GCC is complaining for missing initializer. I am assuming the intended action  here is default construction. Passing `{}` makes compiler happy.