### PR TITLE
Fix error when compiling JUCE master branch with VC++ 2013

### DIFF
--- a/modules/juce_audio_processors/utilities/juce_AudioProcessorValueTreeState.h
+++ b/modules/juce_audio_processors/utilities/juce_AudioProcessorValueTreeState.h
@@ -149,6 +149,7 @@ public:
 
     private:
         struct Pimpl;
+        friend struct ContainerDeletePolicy<Pimpl>;
         ScopedPointer<Pimpl> pimpl;
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (SliderAttachment)
     };
@@ -172,6 +173,7 @@ public:
 
     private:
         struct Pimpl;
+        friend struct ContainerDeletePolicy<Pimpl>;
         ScopedPointer<Pimpl> pimpl;
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ComboBoxAttachment)
     };
@@ -195,6 +197,7 @@ public:
 
     private:
         struct Pimpl;
+        friend struct ContainerDeletePolicy<Pimpl>;
         ScopedPointer<Pimpl> pimpl;
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ButtonAttachment)
     };


### PR DESCRIPTION
#### What's this PR do?
Fix the following error when compiling JUCE master branch with VC++ 2013:

> Error C2248 'juce::AudioProcessorValueTreeState::SliderAttachment::Pimpl' : **cannot access private struct declared in class** 'juce::AudioProcessorValueTreeState::SliderAttachment' modules\juce_core\memory\juce_containerdeletepolicy.h 58


#### Where should the reviewer start?
Small changes was made in the file juce_AudioProcessorValueTreeState.h

#### Any background context you want to provide?
* Juce from master branch.

* Microsoft Visual Studio Professional 2013
  Version 12.0.40629.00 Update 5
  Visual C++ 2013