### PR TITLE
Split out JuceAppStartupDelegate to header file

### DIFF
--- a/modules/juce_gui_basics/native/juce_ios_Windowing.h
+++ b/modules/juce_gui_basics/native/juce_ios_Windowing.h
@@ -1,0 +1,21 @@
+#ifndef juce_ios_Windowing_h
+#define juce_ios_Windowing_h
+
+@interface JuceAppStartupDelegate : NSObject <UIApplicationDelegate>
+{
+}
+
+@property (strong, nonatomic) UIWindow *window;
+
+- (void) applicationDidFinishLaunching: (UIApplication*) application;
+- (void) applicationWillTerminate: (UIApplication*) application;
+- (void) applicationDidEnterBackground: (UIApplication*) application;
+- (void) applicationWillEnterForeground: (UIApplication*) application;
+- (void) applicationDidBecomeActive: (UIApplication*) application;
+- (void) applicationWillResignActive: (UIApplication*) application;
+
+@end
+
+
+
+#endif /* juce_ios_Windowing_h */

--- a/modules/juce_gui_basics/native/juce_ios_Windowing.mm
+++ b/modules/juce_gui_basics/native/juce_ios_Windowing.mm
@@ -35,20 +35,10 @@ Array<AppInactivityCallback*> appBecomingInactiveCallbacks;
 
 } // (juce namespace)
 
-@interface JuceAppStartupDelegate : NSObject <UIApplicationDelegate>
-{
+#import "juce_ios_Windowing.h"
+
+@implementation JuceAppStartupDelegate {
 }
-
-- (void) applicationDidFinishLaunching: (UIApplication*) application;
-- (void) applicationWillTerminate: (UIApplication*) application;
-- (void) applicationDidEnterBackground: (UIApplication*) application;
-- (void) applicationWillEnterForeground: (UIApplication*) application;
-- (void) applicationDidBecomeActive: (UIApplication*) application;
-- (void) applicationWillResignActive: (UIApplication*) application;
-
-@end
-
-@implementation JuceAppStartupDelegate
 
 - (void) applicationDidFinishLaunching: (UIApplication*) application
 {


### PR DESCRIPTION
This pull request is to make the `window` property available from `JuceAppStartupDelegate`, as it is on the standard iOS `AppDelegate`. This is necessary for some iOS libraries to function that expect the window property on the current `UIApplication` instance.

##### Usage
I have a custom `MainWindow` Objective-C++ class that creates the initial `UIWindow` instance:
```Objective-C++
#import "<Path-to-JUCE>/modules/juce_gui_basics/native/juce_ios_Windowing.h"
//...
MainWindow::MainWindow (String name)  : DocumentWindow (name,
                                                        Colours::lightgrey,
                                                        DocumentWindow::allButtons)
{
    //...
    JuceAppStartupDelegate *appDelegate = (JuceAppStartupDelegate *)[[UIApplication sharedApplication] delegate];

    appDelegate.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
    appDelegate.window.backgroundColor = [UIColor whiteColor];
    // ...
}
```

It would be convenient and cleaner to have the new header file in `JuceHeader.h` but given the rarity of potential usage maybe its ok to include it from the JUCE modules folder.  