### PR TITLE
Fix for repaint of components that are cached and scaled

### DIFF
--- a/modules/juce_gui_basics/components/juce_Component.cpp
+++ b/modules/juce_gui_basics/components/juce_Component.cpp
@@ -792,7 +792,7 @@ public:
             validArea.clear();
         }
 
-        if (! validArea.containsRectangle (compBounds))
+        if (! validArea.containsRectangle (imageBounds))
         {
             Graphics imG (image);
             LowLevelGraphicsContext& lg = imG.getInternalContext();


### PR DESCRIPTION
The test for valid areas needs to use the scaled image bounds.