### PR TITLE
Fix for insidious bug in AAX sidechain support

### DIFF
--- a/modules/juce_audio_plugin_client/AAX/juce_AAX_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/AAX/juce_AAX_Wrapper.cpp
@@ -968,6 +968,7 @@ struct AAXClasses
                         pluginInstance->prepareToPlay (sampleRate, bufferSize);
                         maxBufferSize = bufferSize;
                         sideChainBuffer.realloc (static_cast<size_t> (maxBufferSize));
+                        sideChainBuffer.clear   (static_cast<size_t> (maxBufferSize));
                     }
                 }
 
@@ -1088,7 +1089,10 @@ struct AAXClasses
 
             hasSidechain = enableAuxBusesForCurrentFormat (busUtils, inputSet, outputSet);
             if (hasSidechain)
+            {
                 sideChainBuffer.realloc (static_cast<size_t> (maxBufferSize));
+                sideChainBuffer.clear   (static_cast<size_t> (maxBufferSize));
+            }
 
             // recheck the format
             if ( (busUtils.getBusCount (true)  > 0 && busUtils.getChannelSet (true, 0)  != inputSet)

--- a/modules/juce_audio_plugin_client/AAX/juce_AAX_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/AAX/juce_AAX_Wrapper.cpp
@@ -1222,7 +1222,7 @@ struct AAXClasses
         {
             const JUCEAlgorithmContext& i = **iter;
 
-            int sideChainBufferIdx = i.pluginInstance->parameters.supportsSidechain() && i.sideChainBuffers != nullptr
+            int sideChainBufferIdx = i.pluginInstance->parameters.supportsSidechain() && i.sideChainBuffers != nullptr && *i.sideChainBuffers > 0
                                          ? static_cast<int> (*i.sideChainBuffers)
                                          : -1;
 


### PR DESCRIPTION
(Disclaimer: I know you are not allowed to take pull requests for copyright issues. Feel free to integrate this code the way you like, I grant you permission to take this pull request without claiming rights on it)

In AAX, the index of the first sidechain channel passed by Pro Tools to indicate that no sidechain is connected is 0, not -1

As a consequence, an additional test for it to be > 0 is required.

Yes, I know that the documentation for AddSideChainIn() in the AAX SDK says:
"The index of the plug-in's first side-chain input channel within the array of input audio buffers"
thus it would seem that 0 would be a perfectly valid index for the sidechain channel.

Unfortunately, that is not the case, and it resulted in the sidechain being a duplicate of the main input bus when "no key input" was selected for the plug-in.

A confirmation of the fact that 0 is to be intended as to mean "no sidechain connected" is found in the post by Rob Majors linked below, in the developers forum for AAX (accessible only to those who are registered as AAX developers)

https://developer.digidesign.com/phpbb/viewtopic.php?f=95&t=1055&p=4821