### PR TITLE
Fixed code and comment spelling errors.

### DIFF
--- a/examples/ComponentTutorialExample/Source/ToggleLightGridComponent.h
+++ b/examples/ComponentTutorialExample/Source/ToggleLightGridComponent.h
@@ -25,7 +25,7 @@ public:
         // Adds the child light components and makes them visible
         // within this component.
         // (they currently rely on having a default constructor
-        // so they dont have to be individually initialised)
+        // so they don't have to be individually initialised)
         for (int i = 0; i < numX * numY; ++i)
             addAndMakeVisible (toggleLights[i]);
     }

--- a/examples/Demo/Source/Demos/AudioRecordingDemo.cpp
+++ b/examples/Demo/Source/Demos/AudioRecordingDemo.cpp
@@ -122,7 +122,7 @@ public:
         {
             activeWriter->write (inputChannelData, numSamples);
 
-            // Create an AudioSampleBuffer to wrap our incomming data, note that this does no allocations or copies, it simply references our input data
+            // Create an AudioSampleBuffer to wrap our incoming data, note that this does no allocations or copies, it simply references our input data
             const AudioSampleBuffer buffer (const_cast<float**> (inputChannelData), thumbnail.getNumChannels(), numSamples);
             thumbnail.addBlock (nextSampleNum, buffer, 0, numSamples);
             nextSampleNum += numSamples;

--- a/examples/Demo/Source/Demos/FontsDemo.cpp
+++ b/examples/Demo/Source/Demos/FontsDemo.cpp
@@ -90,7 +90,7 @@ public:
         verticalDividerBar = new StretchableLayoutResizerBar (&verticalLayout, 1, true);
         addAndMakeVisible (verticalDividerBar);
 
-        // ..and pick a random font to select intially
+        // ..and pick a random font to select initially
         listBox.selectRow (Random::getSystemRandom().nextInt (fonts.size()));
 
         demoTextBox.setMultiLine (true);

--- a/examples/NetworkGraphicsDemo/README.txt
+++ b/examples/NetworkGraphicsDemo/README.txt
@@ -5,7 +5,7 @@
 This example is an app that we threw together to run as a demo of JUCE on our
 booth at CES 2016.
 
-It allows a collection of heterogenous devices on a local network to collectively
+It allows a collection of heterogeneous devices on a local network to collectively
 draw parts of a large animated vector graphic image that is being generated and
 broadcast by one of the machines (the 'master').
 

--- a/examples/OSCMonitor/Source/MainComponent.h
+++ b/examples/OSCMonitor/Source/MainComponent.h
@@ -169,7 +169,7 @@ private:
         AlertWindow::showMessageBoxAsync (
             AlertWindow::WarningIcon,
             "Unknown error",
-            "An unknown error occured while trying to disconnect from UPD port.",
+            "An unknown error occurred while trying to disconnect from UPD port.",
             "OK");
     }
 

--- a/extras/Projucer/Source/LiveBuildEngine/projucer_DiagnosticMessage.h
+++ b/extras/Projucer/Source/LiveBuildEngine/projucer_DiagnosticMessage.h
@@ -113,7 +113,7 @@ struct DiagnosticReceiver
 struct DiagnosticList
 {
     // after some research, it seems that notes never come on their own
-    // i.e. they always have a warning / error preceeding them
+    // i.e. they always have a warning / error preceding them
     // so we can use this to keep notes and their associated notes together
     // by keeping track of the last message
     DiagnosticMessage lastMessage;

--- a/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
+++ b/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
@@ -691,7 +691,7 @@ public:
 
             { const ScopedLock sl (callbackLock); }
 
-            // wait until it's definately stopped calling back..
+            // wait until it's definitely stopped calling back..
             for (int i = 40; --i >= 0;)
             {
                 Thread::sleep (50);

--- a/modules/juce_audio_devices/native/juce_win32_ASIO.cpp
+++ b/modules/juce_audio_devices/native/juce_win32_ASIO.cpp
@@ -1567,7 +1567,7 @@ private:
                             DWORD dsize = sizeof (pathName);
 
                             if (RegQueryValueEx (pathKey, 0, 0, &dtype, (LPBYTE) pathName, &dsize) == ERROR_SUCCESS)
-                                // In older code, this used to check for the existance of the file, but there are situations
+                                // In older code, this used to check for the existence of the file, but there are situations
                                 // where our process doesn't have access to it, but where the driver still loads ok..
                                 ok = (pathName[0] != 0);
 

--- a/modules/juce_audio_formats/codecs/flac/compat.h
+++ b/modules/juce_audio_formats/codecs/flac/compat.h
@@ -29,7 +29,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* This is the prefered location of all CPP hackery to make $random_compiler
+/* This is the preferred location of all CPP hackery to make $random_compiler
  * work like something approaching a C99 (or maybe more accurately GNU99)
  * compiler.
  *

--- a/modules/juce_audio_formats/codecs/flac/libFLAC/bitreader.c
+++ b/modules/juce_audio_formats/codecs/flac/libFLAC/bitreader.c
@@ -143,7 +143,7 @@ static FLAC__bool bitreader_read_from_client_(FLAC__BitReader *br)
 
 	/* before reading, if the existing reader looks like this (say uint32_t is 32 bits wide)
 	 *   bitstream :  11 22 33 44 55            br->words=1 br->bytes=1 (partial tail word is left-justified)
-	 *   buffer[BE]:  11 22 33 44 55 ?? ?? ??   (shown layed out as bytes sequentially in memory)
+	 *   buffer[BE]:  11 22 33 44 55 ?? ?? ??   (shown laid out as bytes sequentially in memory)
 	 *   buffer[LE]:  44 33 22 11 ?? ?? ?? 55   (?? being don't-care)
 	 *                               ^^-------target, bytes=3
 	 * on LE machines, have to byteswap the odd tail word so nothing is

--- a/modules/juce_audio_formats/codecs/flac/libFLAC/stream_decoder.c
+++ b/modules/juce_audio_formats/codecs/flac/libFLAC/stream_decoder.c
@@ -169,7 +169,7 @@ typedef struct FLAC__StreamDecoderPrivate {
 	FLAC__MD5Context md5context;
 	FLAC__byte computed_md5sum[16]; /* this is the sum we computed from the decoded data */
 	/* (the rest of these are only used for seeking) */
-	FLAC__Frame last_frame; /* holds the info of the last frame we seeked to */
+	FLAC__Frame last_frame; /* holds the info of the last frame we sought to */
 	FLAC__uint64 first_frame_offset; /* hint to the seek routine of where in the stream the first audio frame starts */
 	FLAC__uint64 target_sample;
 	unsigned unparseable_frame_count; /* used to tell whether we're decoding a future version of FLAC or just got a bad sync */

--- a/modules/juce_audio_formats/codecs/flac/libFLAC/stream_encoder.c
+++ b/modules/juce_audio_formats/codecs/flac/libFLAC/stream_encoder.c
@@ -1893,7 +1893,7 @@ FLAC_API FLAC__bool FLAC__stream_encoder_set_metadata(FLAC__StreamEncoder *encod
 }
 
 /*
- * These three functions are not static, but not publically exposed in
+ * These three functions are not static, but not publicly exposed in
  * include/FLAC/ either.  They are used by the test suite.
  */
 FLAC_API FLAC__bool FLAC__stream_encoder_disable_constant_subframes(FLAC__StreamEncoder *encoder, FLAC__bool value)

--- a/modules/juce_audio_formats/codecs/flac/metadata.h
+++ b/modules/juce_audio_formats/codecs/flac/metadata.h
@@ -93,7 +93,7 @@
  *  Efficient means the whole file is rewritten at most one time, and only
  *  when necessary.  Level 1 is not efficient only in the case that you
  *  cause more than one metadata block to grow or shrink beyond what can
- *  be accomodated by padding.  In this case you should probably use level
+ *  be accommodated by padding.  In this case you should probably use level
  *  2, which allows you to edit all the metadata for a file in memory and
  *  write it out all at once.
  *

--- a/modules/juce_audio_formats/codecs/oggvorbis/framing.c
+++ b/modules/juce_audio_formats/codecs/oggvorbis/framing.c
@@ -629,7 +629,7 @@ long ogg_sync_pageseek(ogg_sync_state *oy,ogg_page *og){
 }
 
 /* sync the stream and get a page.  Keep trying until we find a page.
-   Supress 'sync errors' after reporting the first.
+   Suppress 'sync errors' after reporting the first.
 
    return values:
    -1) recapture (hole in data)

--- a/modules/juce_audio_formats/codecs/oggvorbis/libvorbis-1.3.2/lib/bitrate.c
+++ b/modules/juce_audio_formats/codecs/oggvorbis/libvorbis-1.3.2/lib/bitrate.c
@@ -199,7 +199,7 @@ int vorbis_bitrate_addblock(vorbis_block *vb){
     }else if(min_target_bits>0 && this_bits<min_target_bits){
       bm->minmax_reservoir+=(this_bits-min_target_bits);
     }else{
-      /* inbetween; we want to take reservoir toward but not past desired_fill */
+      /* between; we want to take reservoir toward but not past desired_fill */
       if(bm->minmax_reservoir>desired_fill){
         if(max_target_bits>0){ /* logical bulletproofing against initialization state */
           bm->minmax_reservoir+=(this_bits-max_target_bits);

--- a/modules/juce_audio_formats/codecs/oggvorbis/libvorbis-1.3.2/lib/block.c
+++ b/modules/juce_audio_formats/codecs/oggvorbis/libvorbis-1.3.2/lib/block.c
@@ -185,7 +185,7 @@ static int _vds_shared_init(vorbis_dsp_state *v,vorbis_info *vi,int encp){
   b->transform[0]=(vorbis_look_transform**)_ogg_calloc(VI_TRANSFORMB,sizeof(*b->transform[0]));
   b->transform[1]=(vorbis_look_transform**)_ogg_calloc(VI_TRANSFORMB,sizeof(*b->transform[1]));
 
-  /* MDCT is tranform 0 */
+  /* MDCT is transform 0 */
 
   b->transform[0][0]=_ogg_calloc(1,sizeof(mdct_lookup));
   b->transform[1][0]=_ogg_calloc(1,sizeof(mdct_lookup));
@@ -947,7 +947,7 @@ int vorbis_synthesis_read(vorbis_dsp_state *v,int n){
 /* intended for use with a specific vorbisfile feature; we want access
    to the [usually synthetic/postextrapolated] buffer and lapping at
    the end of a decode cycle, specifically, a half-short-block worth.
-   This funtion works like pcmout above, except it will also expose
+   This function works like pcmout above, except it will also expose
    this implicit buffer data not normally decoded. */
 int vorbis_synthesis_lapout(vorbis_dsp_state *v,float ***pcm){
   vorbis_info *vi=v->vi;

--- a/modules/juce_audio_formats/codecs/oggvorbis/libvorbis-1.3.2/lib/lsp.c
+++ b/modules/juce_audio_formats/codecs/oggvorbis/libvorbis-1.3.2/lib/lsp.c
@@ -88,7 +88,7 @@ void vorbis_lsp_to_curve(float *curve,int *map,int n,int ln,float *lsp,int m,
     }
 
     if(m&1){
-      /* odd order filter; slightly assymetric */
+      /* odd order filter; slightly asymmetric */
       /* the last coefficient */
       q*=ftmp[0]-w;
       q*=q;
@@ -175,7 +175,7 @@ void vorbis_lsp_to_curve(float *curve,int *map,int n,int ln,float *lsp,int m,
     /* pi,qi normalized collectively, both tracked using qexp */
 
     if(m&1){
-      /* odd order filter; slightly assymetric */
+      /* odd order filter; slightly asymmetric */
       /* the last coefficient */
       qi=(qi>>shift)*labs(ilsp[j-1]-wi);
       pi=(pi>>shift)<<14;
@@ -262,7 +262,7 @@ void vorbis_lsp_to_curve(float *curve,int *map,int n,int ln,float *lsp,int m,
       p *= w-lsp[j];
     }
     if(j==m){
-      /* odd order filter; slightly assymetric */
+      /* odd order filter; slightly asymmetric */
       /* the last coefficient */
       q*=w-lsp[j-1];
       p*=p*(4.f-w*w);

--- a/modules/juce_audio_formats/codecs/oggvorbis/libvorbis-1.3.2/lib/mapping0.c
+++ b/modules/juce_audio_formats/codecs/oggvorbis/libvorbis-1.3.2/lib/mapping0.c
@@ -64,7 +64,7 @@ static void mapping0_pack(vorbis_info *vi,vorbis_info_mapping *vm,
      packed 4 binary zeros here to signify one submapping in use.  We
      now redefine that to mean four bitflags that indicate use of
      deeper features; bit0:submappings, bit1:coupling,
-     bit2,3:reserved. This is backward compatable with all actual uses
+     bit2,3:reserved. This is backward compatible with all actual uses
      of the beta code. */
 
   if(info->submaps>1){

--- a/modules/juce_audio_formats/codecs/oggvorbis/libvorbis-1.3.2/lib/vorbisenc.c
+++ b/modules/juce_audio_formats/codecs/oggvorbis/libvorbis-1.3.2/lib/vorbisenc.c
@@ -1194,9 +1194,9 @@ int vorbis_encode_ctl(vorbis_info *vi,int number,void *arg){
         /* Fetching a new template can alter the base_setting, which
            many other parameters are based on.  Right now, the only
            parameter drawn from the base_setting that can be altered
-           by an encctl is the lowpass, so that is explictly flagged
+           by an encctl is the lowpass, so that is explicitly flagged
            to not be overwritten when we fetch a new template and
-           recompute the dependant settings */
+           recompute the dependent settings */
         new_template = get_setup_template(hi->coupling_p?vi->channels:-1,
                                           vi->rate,
                                           hi->req,

--- a/modules/juce_audio_formats/codecs/oggvorbis/libvorbis-1.3.2/lib/vorbisfile.c
+++ b/modules/juce_audio_formats/codecs/oggvorbis/libvorbis-1.3.2/lib/vorbisfile.c
@@ -258,7 +258,7 @@ static ogg_int64_t _get_prev_page_serial(OggVorbis_File *vf,
         }
 
         if(!_lookup_serialno(ret_serialno,serial_list,serial_n)){
-          /* we fell off the end of the link, which means we seeked
+          /* we fell off the end of the link, which means we sought
              back too far and shouldn't have been looking in that link
              to begin with.  If we found the preferred serial number,
              forget that we saw it. */
@@ -524,7 +524,7 @@ static int _bisect_forward_serialno(OggVorbis_File *vf,
     vorbis_info vi;
     vorbis_comment vc;
 
-    /* the below guards against garbage seperating the last and
+    /* the below guards against garbage separating the last and
        first pages of two links. */
     while(searched<endsearched){
       ogg_int64_t bisect;
@@ -1807,7 +1807,7 @@ vorbis_info *ov_info(OggVorbis_File *vf,int link){
   }
 }
 
-/* grr, strong typing, grr, no templates/inheritence, grr */
+/* grr, strong typing, grr, no templates/inheritance, grr */
 vorbis_comment *ov_comment(OggVorbis_File *vf,int link){
   if(vf->seekable){
     if(link<0)

--- a/modules/juce_audio_formats/codecs/oggvorbis/ogg.h
+++ b/modules/juce_audio_formats/codecs/oggvorbis/ogg.h
@@ -82,7 +82,7 @@ typedef struct {
   ogg_int64_t  packetno;      /* sequence number for decode; the framing
                              knows where there's a hole in the data,
                              but we need coupling so that the codec
-                             (which is in a seperate abstraction
+                             (which is in a separate abstraction
                              layer) also knows about the gap */
   ogg_int64_t   granulepos;
 
@@ -102,7 +102,7 @@ typedef struct {
   ogg_int64_t  packetno;     /* sequence number for decode; the framing
 				knows where there's a hole in the data,
 				but we need coupling so that the codec
-				(which is in a seperate abstraction
+				(which is in a separate abstraction
 				layer) also knows about the gap */
 } ogg_packet;
 

--- a/modules/juce_audio_plugin_client/AAX/juce_AAX_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/AAX/juce_AAX_Wrapper.cpp
@@ -1165,7 +1165,7 @@ struct AAXClasses
         // and the size of the data returned. To avoid generating
         // it again in GetChunk, we need to store it somewhere.
         // However, as GetChunkSize and GetChunk can be called
-        // on different threads, we store it in thread dependant storage
+        // on different threads, we store it in thread dependent storage
         // in a hash map with the thread id as a key.
         mutable HashMap<Thread::ThreadID, ChunkMemoryBlock::Ptr> perThreadFilterData;
         CriticalSection perThreadDataLock;

--- a/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUBase.h
+++ b/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUBase.h
@@ -707,7 +707,7 @@ public:
 #pragma mark AU Music Base Dispatch
 
 #if !TARGET_OS_IPHONE
-// these methods are deprecated, so we don't include them except for compatability
+// these methods are deprecated, so we don't include them except for compatibility
 	/*! @method PrepareInstrument */
 	virtual OSStatus			PrepareInstrument(MusicDeviceInstrumentID inInstrument) { return kAudio_UnimplementedError; }
 

--- a/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUPlugInDispatch.cpp
+++ b/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUPlugInDispatch.cpp
@@ -437,7 +437,7 @@ static OSStatus AUMethodStop(void *self)
 // ------------------------------------------------------------------------------------------------
 
 #if !CA_BASIC_AU_FEATURES
-// I don't know what I'm doing here; conflicts with the multiple inheritence in MusicDeviceBase.
+// I don't know what I'm doing here; conflicts with the multiple inheritance in MusicDeviceBase.
 static OSStatus AUMethodMIDIEvent(void *self, UInt32 inStatus, UInt32 inData1, UInt32 inData2, UInt32 inOffsetSampleFrame)
 {
 	OSStatus result = noErr;

--- a/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/CAAtomic.h
+++ b/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/CAAtomic.h
@@ -80,7 +80,7 @@ inline SInt32 CAAtomicAdd32Barrier(SInt32 theAmt, volatile SInt32* theValue)
 #if TARGET_OS_WIN32
 	long lRetVal = InterlockedExchangeAdd((volatile long*)theValue, theAmt);
 	// InterlockedExchangeAdd returns the original value which differs from OSX version.
-	// At this point the addition would have occured and hence returning the new value
+	// At this point the addition would have occurred and hence returning the new value
 	// to keep it sync with OSX.
 	return lRetVal + theAmt;
 #else

--- a/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/CAMutex.cpp
+++ b/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/CAMutex.cpp
@@ -249,7 +249,7 @@ bool	CAMutex::Try(bool& outWasLocked)
 		}
 		else
 		{
-			//	any other return value means something really bad happenned
+			//	any other return value means something really bad happened
 			ThrowIfError(theError, CAException(theError), "CAMutex::Try: call to pthread_mutex_trylock failed");
 		}
 	}
@@ -292,7 +292,7 @@ bool	CAMutex::Try(bool& outWasLocked)
 		}
 		else
 		{
-			//	any other return value means something really bad happenned
+			//	any other return value means something really bad happened
 			ThrowIfError(theError, CAException(GetLastError()), "CAMutex::Try: call to lock the mutex failed");
 		}
 	}

--- a/modules/juce_audio_plugin_client/utility/juce_PluginBusUtilities.h
+++ b/modules/juce_audio_plugin_client/utility/juce_PluginBusUtilities.h
@@ -341,7 +341,7 @@ private:
         AudioChannelSet set;
 
         // If the plug-in does not complain about setting it's layout to an undefined layout
-        // then we assume that the plug-in ignores the layout alltogether
+        // then we assume that the plug-in ignores the layout altogether
         for (int i = 0; i < channelNum; ++i)
             set.addChannel (static_cast<AudioChannelSet::ChannelType> (pseudoChannelBitNum + i));
 

--- a/modules/juce_audio_processors/format/juce_AudioPluginFormatManager.h
+++ b/modules/juce_audio_processors/format/juce_AudioPluginFormatManager.h
@@ -106,7 +106,7 @@ public:
 
         If you intend to instantiate a AudioUnit v3 plug-in then you must use
         this non-blocking asynchrous version - or call the synchrous method
-        from an auxilliary thread.
+        from an auxiliary thread.
     */
     void createPluginInstanceAsync (const PluginDescription& description,
                                     double initialSampleRate,

--- a/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm
+++ b/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm
@@ -1902,7 +1902,7 @@ void AudioUnitPluginFormat::createPluginInstance (const PluginDescription& desc,
                 }
                 else
                 {
-                    String errMsg = NEEDS_TRANS ("An OS error ocurred during initialisation of the plug-in (XXX)");
+                    String errMsg = NEEDS_TRANS ("An OS error occurred during initialisation of the plug-in (XXX)");
                     originalCallback (passUserData, nullptr, errMsg.replace ("XXX", String (err)));
                 }
 

--- a/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.h
+++ b/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.h
@@ -36,7 +36,7 @@ public:
     ~VSTPluginFormat();
 
     //==============================================================================
-    /** Attempts to retreive the VSTXML data from a plugin.
+    /** Attempts to retrieve the VSTXML data from a plugin.
         Will return nullptr if the plugin isn't a VST, or if it doesn't have any VSTXML.
     */
     static const XmlElement* getVSTXML (AudioPluginInstance* plugin);

--- a/modules/juce_audio_processors/processors/juce_PluginDescription.h
+++ b/modules/juce_audio_processors/processors/juce_PluginDescription.h
@@ -118,7 +118,7 @@ public:
         given identifier string.
 
         Note that this isn't quite as simple as them just calling createIdentifierString()
-        and comparing the strings, because the identifers can differ (thanks to shell plug-ins).
+        and comparing the strings, because the identifiers can differ (thanks to shell plug-ins).
     */
     bool matchesIdentifierString (const String& identifierString) const;
 

--- a/modules/juce_audio_utils/gui/juce_MidiKeyboardComponent.h
+++ b/modules/juce_audio_utils/gui/juce_MidiKeyboardComponent.h
@@ -362,7 +362,7 @@ protected:
     */
     virtual void mouseUpOnKey (int midiNoteNumber, const MouseEvent& e);
 
-    /** Calculates the positon of a given midi-note.
+    /** Calculates the position of a given midi-note.
 
         This can be overridden to create layouts with custom key-widths.
 

--- a/modules/juce_core/containers/juce_HashMap.h
+++ b/modules/juce_core/containers/juce_HashMap.h
@@ -372,7 +372,7 @@ public:
         }
         @endcode
 
-        The order in which items are iterated bears no resemblence to the order in which
+        The order in which items are iterated bears no resemblance to the order in which
         they were originally added!
 
         Obviously as soon as you call any non-const methods on the original hash-map, any

--- a/modules/juce_core/maths/juce_MathsFunctions.h
+++ b/modules/juce_core/maths/juce_MathsFunctions.h
@@ -93,7 +93,7 @@ typedef unsigned int                uint32;
 #endif
 
 //==============================================================================
-// Some indispensible min/max functions
+// Some indispensable min/max functions
 
 /** Returns the larger of two values. */
 template <typename Type>

--- a/modules/juce_core/maths/juce_NormalisableRange.h
+++ b/modules/juce_core/maths/juce_NormalisableRange.h
@@ -150,7 +150,7 @@ public:
     /** An optional skew factor that alters the way values are distribute across the range.
 
         The skew factor lets you skew the mapping logarithmically so that larger or smaller
-        values are given a larger proportion of the avilable space.
+        values are given a larger proportion of the available space.
 
         A factor of 1.0 has no skewing effect at all. If the factor is < 1.0, the lower end
         of the range will fill more of the slider's length; if the factor is > 1.0, the upper

--- a/modules/juce_core/memory/juce_Atomic.h
+++ b/modules/juce_core/memory/juce_Atomic.h
@@ -147,7 +147,7 @@ public:
    #endif
 
     /** The raw value that this class operates on.
-        This is exposed publically in case you need to manipulate it directly
+        This is exposed publicly in case you need to manipulate it directly
         for performance reasons.
     */
     volatile Type value;

--- a/modules/juce_core/memory/juce_ScopedPointer.h
+++ b/modules/juce_core/memory/juce_ScopedPointer.h
@@ -56,7 +56,7 @@
     can use the release() method.
 
     Something to note is the main difference between this class and the std::auto_ptr class,
-    which is that ScopedPointer provides a cast-to-object operator, wheras std::auto_ptr
+    which is that ScopedPointer provides a cast-to-object operator, whereas std::auto_ptr
     requires that you always call get() to retrieve the pointer. The advantages of providing
     the cast is that you don't need to call get(), so can use the ScopedPointer in pretty much
     exactly the same way as a raw pointer. The disadvantage is that the compiler is free to

--- a/modules/juce_core/network/juce_Socket.h
+++ b/modules/juce_core/network/juce_Socket.h
@@ -247,7 +247,7 @@ public:
         This is useful if you need to know to which port the OS has actually bound your
         socket when bindToPort was called with zero.
 
-        Returns -1 if the socket didn't bind to any port yet or an error occured. */
+        Returns -1 if the socket didn't bind to any port yet or an error occurred. */
     int getBoundPort() const noexcept;
 
     /** Returns the OS's socket handle that's currently open. */

--- a/modules/juce_core/network/juce_URL.h
+++ b/modules/juce_core/network/juce_URL.h
@@ -345,7 +345,7 @@ public:
         If it fails, or if the text that it reads can't be parsed as XML, this will
         return 0.
 
-        When it returns a valid XmlElement object, the caller is responsibile for deleting
+        When it returns a valid XmlElement object, the caller is responsible for deleting
         this object when no longer needed.
 
         Note that on some platforms (Android, for example) it's not permitted to do any network

--- a/modules/juce_core/streams/juce_MemoryOutputStream.h
+++ b/modules/juce_core/streams/juce_MemoryOutputStream.h
@@ -42,7 +42,7 @@ class JUCE_API  MemoryOutputStream  : public OutputStream
 public:
     //==============================================================================
     /** Creates an empty memory stream, ready to be written into.
-        @param initialSize  the intial amount of capacity to allocate for writing into
+        @param initialSize  the initial amount of capacity to allocate for writing into
     */
     MemoryOutputStream (size_t initialSize = 256);
 

--- a/modules/juce_core/zip/zlib/deflate.h
+++ b/modules/juce_core/zip/zlib/deflate.h
@@ -190,7 +190,7 @@ typedef struct internal_state {
     int nice_match; /* Stop searching when current match exceeds this */
 
                 /* used by trees.c: */
-    /* Didn't use ct_data typedef below to supress compiler warning */
+    /* Didn't use ct_data typedef below to suppress compiler warning */
     struct ct_data_s dyn_ltree[HEAP_SIZE];   /* literal and length tree */
     struct ct_data_s dyn_dtree[2*D_CODES+1]; /* distance tree */
     struct ct_data_s bl_tree[2*BL_CODES+1];  /* Huffman tree for bit lengths */

--- a/modules/juce_graphics/fonts/juce_GlyphArrangement.h
+++ b/modules/juce_graphics/fonts/juce_GlyphArrangement.h
@@ -195,7 +195,7 @@ public:
                            float maxLineWidth,
                            Justification horizontalLayout);
 
-    /** Tries to fit some text withing a given space.
+    /** Tries to fit some text within a given space.
 
         This does its best to make the given text readable within the specified rectangle,
         so it useful for labelling things.

--- a/modules/juce_graphics/geometry/juce_Line.h
+++ b/modules/juce_graphics/geometry/juce_Line.h
@@ -176,7 +176,7 @@ public:
                                 the intersection (if the lines intersect). If the lines
                                 are parallel, this will just be set to the position
                                 of one of the line's endpoints.
-        @returns    true if the line segments intersect; false if they dont. Even if they
+        @returns    true if the line segments intersect; false if they don't. Even if they
                     don't intersect, the intersection coordinates returned will still
                     be valid
     */

--- a/modules/juce_graphics/geometry/juce_Path.h
+++ b/modules/juce_graphics/geometry/juce_Path.h
@@ -98,7 +98,7 @@ public:
 
     /** Checks whether a point lies within the path.
 
-        This is only relevent for closed paths (see closeSubPath()), and
+        This is only relevant for closed paths (see closeSubPath()), and
         may produce false results if used on a path which has open sub-paths.
 
         The path's winding rule is taken into account by this method.
@@ -114,7 +114,7 @@ public:
 
     /** Checks whether a point lies within the path.
 
-        This is only relevent for closed paths (see closeSubPath()), and
+        This is only relevant for closed paths (see closeSubPath()), and
         may produce false results if used on a path which has open sub-paths.
 
         The path's winding rule is taken into account by this method.

--- a/modules/juce_graphics/geometry/juce_PathStrokeType.cpp
+++ b/modules/juce_graphics/geometry/juce_PathStrokeType.cpp
@@ -316,7 +316,7 @@ namespace PathStrokeHelpers
 
             if (style == PathStrokeType::square)
             {
-                // sqaure ends
+                // square ends
                 destPath.lineTo (offx1, offy1);
                 destPath.lineTo (offx2, offy2);
                 destPath.lineTo (x2, y2);

--- a/modules/juce_graphics/geometry/juce_Rectangle.h
+++ b/modules/juce_graphics/geometry/juce_Rectangle.h
@@ -773,7 +773,7 @@ public:
     }
 
     /** Returns the smallest integer-aligned rectangle that completely contains this one.
-        This is only relevent for floating-point rectangles, of course.
+        This is only relevant for floating-point rectangles, of course.
         @see toFloat(), toNearestInt()
     */
     Rectangle<int> getSmallestIntegerContainer() const noexcept

--- a/modules/juce_graphics/image_formats/jpglib/jmorecfg.h
+++ b/modules/juce_graphics/image_formats/jpglib/jmorecfg.h
@@ -184,7 +184,7 @@ typedef unsigned int JDIMENSION;
 #define METHODDEF(type)		static type
 /* a function used only in its module: */
 #define LOCAL(type)		static type
-/* a function referenced thru EXTERNs: */
+/* a function referenced through EXTERNs: */
 #define GLOBAL(type)		type
 /* a reference to a GLOBAL function: */
 #define EXTERN(type)		extern type

--- a/modules/juce_graphics/image_formats/pnglib/png.c
+++ b/modules/juce_graphics/image_formats/pnglib/png.c
@@ -1016,7 +1016,7 @@ png_colorspace_set_gamma(png_const_structrp png_ptr,
    png_colorspacerp colorspace, png_fixed_point gAMA)
 {
    /* Changed in libpng-1.5.4 to limit the values to ensure overflow can't
-    * occur.  Since the fixed point representation is assymetrical it is
+    * occur.  Since the fixed point representation is asymmetrical it is
     * possible for 1/gamma to overflow the limit of 21474 and this means the
     * gamma value must be at least 5/100000 and hence at most 20000.0.  For
     * safety the limits here are a little narrower.  The values are 0.00016 to
@@ -1894,7 +1894,7 @@ png_icc_check_header(png_const_structrp png_ptr, png_colorspacerp colorspace,
     */
 
    /* Data checks (could be skipped).  These checks must be independent of the
-    * version number; however, the version number doesn't accomodate changes in
+    * version number; however, the version number doesn't accommodate changes in
     * the header fields (just the known tags and the interpretation of the
     * data.)
     */
@@ -1979,7 +1979,7 @@ png_icc_check_header(png_const_structrp png_ptr, png_colorspacerp colorspace,
             "invalid embedded Abstract ICC profile");
 
       case 0x6C696E6B: /* 'link' */
-         /* DeviceLink profiles cannnot be interpreted in a non-device specific
+         /* DeviceLink profiles cannot be interpreted in a non-device specific
           * fashion, if an app uses the AToB0Tag in the profile the results are
           * undefined unless the result is sent to the intended device,
           * therefore a DeviceLink profile should not be found embedded in a
@@ -2497,7 +2497,7 @@ png_check_IHDR(png_const_structrp png_ptr,
 
 #if defined(PNG_sCAL_SUPPORTED) || defined(PNG_pCAL_SUPPORTED)
 /* ASCII to fp functions */
-/* Check an ASCII formated floating point value, see the more detailed
+/* Check an ASCII formatted floating point value, see the more detailed
  * comments in pngpriv.h
  */
 /* The following is used internally to preserve the sticky flags */

--- a/modules/juce_graphics/image_formats/pnglib/png.h
+++ b/modules/juce_graphics/image_formats/pnglib/png.h
@@ -1327,7 +1327,7 @@ PNG_FIXED_EXPORT(228, void, png_set_alpha_mode_fixed, (png_structrp png_ptr,
  *
  * png_set_alpha_mode(pp, PNG_ALPHA_PNG, PNG_GAMMA_MAC);
  *    In this case the output is assumed to be something like an sRGB conformant
- *    display preceeded by a power-law lookup table of power 1.45.  This is how
+ *    display preceded by a power-law lookup table of power 1.45.  This is how
  *    early Mac systems behaved.
  *
  * png_set_alpha_mode(pp, PNG_ALPHA_STANDARD, PNG_GAMMA_LINEAR);
@@ -1846,12 +1846,12 @@ PNG_EXPORT(218, png_byte, png_get_current_pass_number, (png_const_structrp));
  *
  * The integer return from the callback function is interpreted thus:
  *
- * negative: An error occured, png_chunk_error will be called.
+ * negative: An error occurred, png_chunk_error will be called.
  *     zero: The chunk was not handled, the chunk will be saved. A critical
  *           chunk will cause an error at this point unless it is to be saved.
  * positive: The chunk was handled, libpng will ignore/discard it.
  *
- * See "INTERACTION WTIH USER CHUNK CALLBACKS" below for important notes about
+ * See "INTERACTION WITH USER CHUNK CALLBACKS" below for important notes about
  * how this behavior will change in libpng 1.7
  */
 PNG_EXPORT(88, void, png_set_read_user_chunk_fn, (png_structrp png_ptr,
@@ -2386,7 +2386,7 @@ PNG_EXPORT(171, void, png_set_sCAL_s, (png_const_structrp png_ptr,
  * to specifying "NEVER", however when "AS_DEFAULT" is used for specific chunks
  * it simply resets the behavior to the libpng default.
  *
- * INTERACTION WTIH USER CHUNK CALLBACKS:
+ * INTERACTION WITH USER CHUNK CALLBACKS:
  * The per-chunk handling is always used when there is a png_user_chunk_ptr
  * callback and the callback returns 0; the chunk is then always stored *unless*
  * it is critical and the per-chunk setting is other than ALWAYS.  Notice that
@@ -2784,7 +2784,7 @@ PNG_EXPORT(207, void, png_save_uint_16, (png_bytep buf, unsigned int i));
  * The simplified API hides the details of both libpng and the PNG file format
  * itself.  It allows PNG files to be read into a very limited number of
  * in-memory bitmap formats or to be written from the same formats.  If these
- * formats do not accomodate your needs then you can, and should, use the more
+ * formats do not accommodate your needs then you can, and should, use the more
  * sophisticated APIs above - these support a wide variety of in-memory formats
  * and a wide variety of sophisticated transformations to those formats as well
  * as a wide variety of APIs to manipulate ancillary information.

--- a/modules/juce_graphics/image_formats/pnglib/pnginfo.h
+++ b/modules/juce_graphics/image_formats/pnglib/pnginfo.h
@@ -240,7 +240,7 @@ defined(PNG_READ_BACKGROUND_SUPPORTED)
    /* The sCAL chunk describes the actual physical dimensions of the
     * subject matter of the graphic.  The chunk contains a unit specification
     * a byte value, and two ASCII strings representing floating-point
-    * values.  The values are width and height corresponsing to one pixel
+    * values.  The values are width and height corresponding to one pixel
     * in the image.  Data values are valid if (valid & PNG_INFO_sCAL) is
     * non-zero.
     */

--- a/modules/juce_graphics/image_formats/pnglib/pngread.c
+++ b/modules/juce_graphics/image_formats/pnglib/pngread.c
@@ -1133,7 +1133,7 @@ png_read_png(png_structrp png_ptr, png_inforp info_ptr,
 #  define E_LINEAR8 4 /* 8-bit linear: only from a file value */
 
 /* Color-map processing: after libpng has run on the PNG image further
- * processing may be needed to conver the data to color-map indicies.
+ * processing may be needed to conver the data to color-map indices.
  */
 #define PNG_CMAP_NONE      0
 #define PNG_CMAP_GA        1 /* Process GA data to a color-map with alpha */
@@ -2093,7 +2093,7 @@ png_image_read_colormap(png_voidp argument)
             data_encoding = E_FILE;
 
             /* The rows from libpng, while technically gray values, are now also
-             * color-map indicies; however, they may need to be expanded to 1
+             * color-map indices; however, they may need to be expanded to 1
              * byte per pixel.  This is what png_set_packing does (i.e., it
              * unpacks the bit values into bytes.)
              */
@@ -2658,7 +2658,7 @@ png_image_read_colormap(png_voidp argument)
                num_trans = 0;
 
             output_processing = PNG_CMAP_NONE;
-            data_encoding = E_FILE; /* Don't change from color-map indicies */
+            data_encoding = E_FILE; /* Don't change from color-map indices */
             cmap_entries = png_ptr->num_palette;
             if (cmap_entries > 256)
                cmap_entries = 256;
@@ -2698,7 +2698,7 @@ png_image_read_colormap(png_voidp argument)
                      i < num_trans ? trans[i] : 255U, E_FILE/*8-bit*/);
             }
 
-            /* The PNG data may have indicies packed in fewer than 8 bits, it
+            /* The PNG data may have indices packed in fewer than 8 bits, it
              * must be expanded if so.
              */
             if (png_ptr->bit_depth < 8)

--- a/modules/juce_graphics/image_formats/pnglib/pngrtran.c
+++ b/modules/juce_graphics/image_formats/pnglib/pngrtran.c
@@ -1306,7 +1306,7 @@ png_init_read_transformations(png_structrp png_ptr)
 
       else if (png_ptr->screen_gamma != 0)
          /* The converse - assume the file matches the screen, note that this
-          * perhaps undesireable default can (from 1.5.4) be changed by calling
+          * perhaps undesirable default can (from 1.5.4) be changed by calling
           * png_set_alpha_mode (even if the alpha handling mode isn't required
           * or isn't changed from the default.)
           */

--- a/modules/juce_graphics/image_formats/pnglib/pngrutil.c
+++ b/modules/juce_graphics/image_formats/pnglib/pngrutil.c
@@ -98,7 +98,7 @@ png_get_int_32)(png_const_bytep buf)
 png_uint_16 (PNGAPI
 png_get_uint_16)(png_const_bytep buf)
 {
-   /* ANSI-C requires an int value to accomodate at least 16 bits so this
+   /* ANSI-C requires an int value to accommodate at least 16 bits so this
     * works and allows the compiler not to worry about possible narrowing
     * on 32 bit systems.  (Pre-ANSI systems did not make integers smaller
     * than 16 bits either.)
@@ -2789,7 +2789,7 @@ png_handle_unknown(png_structrp png_ptr, png_inforp info_ptr,
                &png_ptr->unknown_chunk);
 
             /* ret is:
-             * negative: An error occured, png_chunk_error will be called.
+             * negative: An error occurred, png_chunk_error will be called.
              *     zero: The chunk was not handled, the chunk will be discarded
              *           unless png_set_keep_unknown_chunks has been used to set
              *           a 'keep' behavior for this particular chunk, in which

--- a/modules/juce_graphics/image_formats/pnglib/pngwutil.c
+++ b/modules/juce_graphics/image_formats/pnglib/pngwutil.c
@@ -868,7 +868,7 @@ png_write_IHDR(png_structrp png_ptr, png_uint_32 width, png_uint_32 height,
    interlace_type=PNG_INTERLACE_NONE;
 #endif
 
-   /* Save the relevent information */
+   /* Save the relevant information */
    png_ptr->bit_depth = (png_byte)bit_depth;
    png_ptr->color_type = (png_byte)color_type;
    png_ptr->interlaced = (png_byte)interlace_type;

--- a/modules/juce_graphics/placement/juce_RectanglePlacement.h
+++ b/modules/juce_graphics/placement/juce_RectanglePlacement.h
@@ -28,7 +28,7 @@
 
 //==============================================================================
 /**
-    Defines the method used to postion some kind of rectangular object within
+    Defines the method used to position some kind of rectangular object within
     a rectangular viewport.
 
     Although similar to Justification, this is more specific, and has some extra

--- a/modules/juce_gui_basics/buttons/juce_Button.h
+++ b/modules/juce_gui_basics/buttons/juce_Button.h
@@ -295,7 +295,7 @@ public:
         E.g. if you are placing two buttons adjacent to each other, you could use this to
         indicate which edges are touching, and the LookAndFeel might choose to drawn them
         without rounded corners on the edges that connect. It's only a hint, so the
-        LookAndFeel can choose to ignore it if it's not relevent for this type of
+        LookAndFeel can choose to ignore it if it's not relevant for this type of
         button.
     */
     void setConnectedEdges (int connectedEdgeFlags);

--- a/modules/juce_gui_basics/commands/juce_ApplicationCommandInfo.h
+++ b/modules/juce_gui_basics/commands/juce_ApplicationCommandInfo.h
@@ -135,7 +135,7 @@ struct JUCE_API  ApplicationCommandInfo
         /** Indicates that the command can't currently be performed.
 
             The ApplicationCommandTarget::getCommandInfo() method must set this flag if it's
-            not currently permissable to perform the command. If the flag is set, then
+            not currently permissible to perform the command. If the flag is set, then
             components that trigger the command, e.g. PopupMenu, may choose to grey-out the
             command or show themselves as not being enabled.
 

--- a/modules/juce_gui_basics/commands/juce_ApplicationCommandTarget.h
+++ b/modules/juce_gui_basics/commands/juce_ApplicationCommandTarget.h
@@ -219,7 +219,7 @@ public:
     */
     bool isCommandActive (const CommandID commandID);
 
-    /** If this object is a Component, this method will seach upwards in its current
+    /** If this object is a Component, this method will search upwards in its current
         UI hierarchy for the next parent component that implements the
         ApplicationCommandTarget class.
 

--- a/modules/juce_gui_basics/components/juce_Component.h
+++ b/modules/juce_gui_basics/components/juce_Component.h
@@ -2036,7 +2036,7 @@ public:
         look-and-feel either, it will just return black.
 
         The colour IDs for various purposes are stored as enums in the components that
-        they are relevent to - for an example, see Slider::ColourIds,
+        they are relevant to - for an example, see Slider::ColourIds,
         Label::ColourIds, TextEditor::ColourIds, TreeView::ColourIds, etc.
 
         @see setColour, isColourSpecified, colourChanged, LookAndFeel::findColour, LookAndFeel::setColour

--- a/modules/juce_gui_basics/components/juce_Desktop.h
+++ b/modules/juce_gui_basics/components/juce_Desktop.h
@@ -159,7 +159,7 @@ public:
 
         If allowMenusAndBars is true, things like the menu and dock (on mac) are still
         allowed to pop up when the mouse moves onto them. If this is false, it'll try
-        to hide as much on-screen paraphenalia as possible.
+        to hide as much on-screen paraphernalia as possible.
     */
     void setKioskModeComponent (Component* componentToUse,
                                 bool allowMenusAndBars = true);

--- a/modules/juce_gui_basics/filebrowser/juce_FileBrowserComponent.h
+++ b/modules/juce_gui_basics/filebrowser/juce_FileBrowserComponent.h
@@ -59,7 +59,7 @@ public:
         canSelectFiles                  = 4,    /**< specifies that the user can select files (can be used in
                                                      conjunction with canSelectDirectories). */
         canSelectDirectories            = 8,    /**< specifies that the user can select directories (can be used in
-                                                     conjuction with canSelectFiles). */
+                                                     conjunction with canSelectFiles). */
         canSelectMultipleItems          = 16,   /**< specifies that the user can select multiple items. */
         useTreeView                     = 32,   /**< specifies that a tree-view should be shown instead of a file list. */
         filenameBoxIsReadOnly           = 64,   /**< specifies that the user can't type directly into the filename box. */

--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel.h
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel.h
@@ -133,7 +133,7 @@ public:
         returned. If none has been set, it will just return Colours::black.
 
         The colour IDs for various purposes are stored as enums in the components that
-        they are relevent to - for an example, see Slider::ColourIds,
+        they are relevant to - for an example, see Slider::ColourIds,
         Label::ColourIds, TextEditor::ColourIds, TreeView::ColourIds, etc.
 
         If you're looking up a colour for use in drawing a component, it's usually

--- a/modules/juce_gui_basics/menus/juce_PopupMenu.cpp
+++ b/modules/juce_gui_basics/menus/juce_PopupMenu.cpp
@@ -407,7 +407,7 @@ public:
             {
                 // we want to dismiss the menu, but if we do it synchronously, then
                 // the mouse-click will be allowed to pass through. That's good, except
-                // when the user clicks on the button that orginally popped the menu up,
+                // when the user clicks on the button that originally popped the menu up,
                 // as they'll expect the menu to go away, and in fact it'll just
                 // come back. So only dismiss synchronously if they're not on the original
                 // comp that we're attached to.

--- a/modules/juce_gui_basics/mouse/juce_LassoComponent.h
+++ b/modules/juce_gui_basics/mouse/juce_LassoComponent.h
@@ -44,7 +44,7 @@ public:
 
     /** Returns the set of items that lie within a given lassoable region.
 
-        Your implementation of this method must find all the relevent items that lie
+        Your implementation of this method must find all the relevant items that lie
         within the given rectangle. and add them to the itemsFound array.
 
         The coordinates are relative to the top-left of the lasso component's parent

--- a/modules/juce_gui_basics/mouse/juce_MouseEvent.h
+++ b/modules/juce_gui_basics/mouse/juce_MouseEvent.h
@@ -182,21 +182,21 @@ public:
     */
     int getDistanceFromDragStart() const noexcept;
 
-    /** Returns the difference between the mouse's current x postion and where it was
+    /** Returns the difference between the mouse's current x position and where it was
         when the button was last pressed.
 
         @see getDistanceFromDragStart
     */
     int getDistanceFromDragStartX() const noexcept;
 
-    /** Returns the difference between the mouse's current y postion and where it was
+    /** Returns the difference between the mouse's current y position and where it was
         when the button was last pressed.
 
         @see getDistanceFromDragStart
     */
     int getDistanceFromDragStartY() const noexcept;
 
-    /** Returns the difference between the mouse's current postion and where it was
+    /** Returns the difference between the mouse's current position and where it was
         when the button was last pressed.
 
         @see getDistanceFromDragStart

--- a/modules/juce_gui_basics/native/juce_win32_Windowing.cpp
+++ b/modules/juce_gui_basics/native/juce_win32_Windowing.cpp
@@ -858,7 +858,7 @@ public:
 
         if (! makeActive)
         {
-            // in this case a broughttofront call won't have occured, so do it now..
+            // in this case a broughttofront call won't have occurred, so do it now..
             handleBroughtToFront();
         }
     }
@@ -1726,7 +1726,7 @@ private:
         if (registerTouchWindow == nullptr)
             return false;
 
-        // Relevent info about touch/pen detection flags:
+        // Relevant info about touch/pen detection flags:
         // https://msdn.microsoft.com/en-us/library/windows/desktop/ms703320(v=vs.85).aspx
         // http://www.petertissen.de/?p=4
 

--- a/modules/juce_gui_basics/widgets/juce_Label.h
+++ b/modules/juce_gui_basics/widgets/juce_Label.h
@@ -148,7 +148,7 @@ public:
 
     /** If the label is attached to the left of another component, this returns true.
 
-        Returns false if the label is above the other component. This is only relevent if
+        Returns false if the label is above the other component. This is only relevant if
         attachToComponent() has been called.
     */
     bool isAttachedOnLeft() const noexcept                                      { return leftOfOwnerComp; }

--- a/modules/juce_gui_basics/widgets/juce_TableHeaderComponent.h
+++ b/modules/juce_gui_basics/widgets/juce_TableHeaderComponent.h
@@ -208,14 +208,14 @@ public:
 
         If there's no such column ID, this will return -1.
 
-        If onlyCountVisibleColumns is true, this will return the index amoungst the visible columns;
+        If onlyCountVisibleColumns is true, this will return the index amongst the visible columns;
         otherwise it'll return the index amongst all the columns, including any hidden ones.
     */
     int getIndexOfColumnId (int columnId, bool onlyCountVisibleColumns) const;
 
     /** Returns the ID of the column at a given index.
 
-        If onlyCountVisibleColumns is true, this will count the index amoungst the visible columns;
+        If onlyCountVisibleColumns is true, this will count the index amongst the visible columns;
         otherwise it'll count it amongst all the columns, including any hidden ones.
 
         If the index is out-of-range, it'll return 0.

--- a/modules/juce_gui_basics/windows/juce_ResizableWindow.h
+++ b/modules/juce_gui_basics/windows/juce_ResizableWindow.h
@@ -154,7 +154,7 @@ public:
     /** Sets the bounds-constrainer object to use for resizing and dragging this window.
 
         A pointer to the object you pass in will be kept, but it won't be deleted
-        by this object, so it's the caller's responsiblity to manage it.
+        by this object, so it's the caller's responsibility to manage it.
 
         If you pass a nullptr, then no contraints will be placed on the positioning of the window.
     */
@@ -216,7 +216,7 @@ public:
 
     /** Restores the window to a previously-saved size and position.
 
-        This restores the window's size, positon and full-screen status from an
+        This restores the window's size, position and full-screen status from an
         string that was previously created with the getWindowStateAsString()
         method.
 

--- a/modules/juce_gui_basics/windows/juce_TopLevelWindow.h
+++ b/modules/juce_gui_basics/windows/juce_TopLevelWindow.h
@@ -79,7 +79,7 @@ public:
         window.
 
         If your app has a few windows open and want to pop up a dialog box for one of
-        them, you can use this to show it in front of the relevent parent window, which
+        them, you can use this to show it in front of the relevant parent window, which
         is a bit neater than just having it appear in the middle of the screen.
 
         If componentToCentreAround is nullptr, then the currently active TopLevelWindow will

--- a/modules/juce_gui_extra/code_editor/juce_CodeDocument.h
+++ b/modules/juce_gui_extra/code_editor/juce_CodeDocument.h
@@ -59,7 +59,7 @@ public:
     class JUCE_API  Position
     {
     public:
-        /** Creates an uninitialised postion.
+        /** Creates an uninitialised position.
             Don't attempt to call any methods on this until you've given it an owner document
             to refer to!
         */
@@ -142,7 +142,7 @@ public:
 
         /** Allows the position to be automatically updated when the document changes.
 
-            If this is set to true, the positon will register with its document so that
+            If this is set to true, the position will register with its document so that
             when the document has text inserted or deleted, this position will be automatically
             moved to keep it at the same position in the text.
         */

--- a/modules/juce_opengl/native/juce_OpenGL_android.h
+++ b/modules/juce_opengl/native/juce_OpenGL_android.h
@@ -68,7 +68,7 @@ public:
         if (surfaceView.get() == nullptr)
             return;
 
-        // add the view to the view hierachy
+        // add the view to the view hierarchy
         // after this the nativecontext can receive callbacks
         env->CallVoidMethod ((jobject) component.getPeer()->getNativeHandle(),
                              AndroidViewGroup.addView, surfaceView.get());

--- a/modules/juce_osc/osc/juce_OSCBundle.h
+++ b/modules/juce_osc/osc/juce_OSCBundle.h
@@ -106,7 +106,7 @@ public:
     bool isEmpty() const noexcept                                { return elements.isEmpty(); }
 
     /** Returns a reference to the OSCBundle element at index i in this bundle.
-        This method does not check the range and results in undefined behavour
+        This method does not check the range and results in undefined behaviour
         in case i < 0 or i >= size().
     */
     OSCBundle::Element& operator[] (const int i) const noexcept

--- a/modules/juce_osc/osc/juce_OSCMessage.h
+++ b/modules/juce_osc/osc/juce_OSCMessage.h
@@ -89,7 +89,7 @@ public:
     bool isEmpty() const noexcept;
 
     /** Returns a reference to the OSCArgument at index i in the OSCMessage object.
-        This method does not check the range and results in undefined behavour
+        This method does not check the range and results in undefined behaviour
         in case i < 0 or i >= size().
     */
     OSCArgument& operator[] (const int i) const noexcept;


### PR DESCRIPTION
These errors were found using 
`$ codespell --quiet-level=3`

I'm not this meticulous.

I may have corrected some library files as well.
If you just want JUCE specific corrections I can make a different pull request.