### PR TITLE
LookAndFeel: added ColourIds for ToggleButton's tickMark

### DIFF
--- a/modules/juce_gui_basics/buttons/juce_ToggleButton.h
+++ b/modules/juce_gui_basics/buttons/juce_ToggleButton.h
@@ -69,7 +69,9 @@ public:
     */
     enum ColourIds
     {
-        textColourId                    = 0x1006501   /**< The colour to use for the button's text. */
+        textColourId                    = 0x1006501,   /**< The colour to use for the button's text. */
+        tickColourId                    = 0x1006502,   /**< The colour to use for the tick mark. */
+        tickDisabledColourId            = 0x1006503    /**< The colour to use for the disabled tick mark. */
     };
 
 protected:

--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V2.cpp
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V2.cpp
@@ -69,6 +69,8 @@ LookAndFeel_V2::LookAndFeel_V2()
         TextButton::textColourOffId,                0xff000000,
 
         ToggleButton::textColourId,                 0xff000000,
+        ToggleButton::tickColourId,                 0xff000000,
+        ToggleButton::tickDisabledColourId,         0xff808080,
 
         TextEditor::backgroundColourId,             0xffffffff,
         TextEditor::textColourId,                   0xff000000,
@@ -295,7 +297,7 @@ void LookAndFeel_V2::drawTickBox (Graphics& g, Component& component,
         tick.lineTo (3.0f, 6.0f);
         tick.lineTo (6.0f, 0.0f);
 
-        g.setColour (isEnabled ? Colours::black : Colours::grey);
+        g.setColour (component.findColour (isEnabled ? ToggleButton::tickColourId : ToggleButton::tickDisabledColourId));
 
         const AffineTransform trans (AffineTransform::scale (w / 9.0f, h / 9.0f)
                                          .translated (x, y));


### PR DESCRIPTION
Added straight forward colour ids for ToggleButton's tick mark.
Please check, if the enum ToggleButton::colourIds are ok.

Disclaimer: By sending this pull request I expressed my wish to merge it into the JUCE codebase. I am aware, that JUCE is distributed as open source as well as under commercial license. I will not claim any copyright nor intellectual property on this material. To construct these changes no sources were copied other than from the public available JUCE codebase.