### PR TITLE
support lambdas for var::NativeFunction by using std::function

### DIFF
--- a/modules/juce_core/containers/juce_Variant.cpp
+++ b/modules/juce_core/containers/juce_Variant.cpp
@@ -368,7 +368,6 @@ class var::VariantType_Binary   : public var::VariantType
 {
 public:
     VariantType_Binary() noexcept {}
-
     static const VariantType_Binary instance;
 
     void cleanUp (ValueUnion& data) const noexcept override                      { delete data.binaryValue; }
@@ -430,7 +429,6 @@ const var::VariantType_Object       var::VariantType_Object::instance;
 const var::VariantType_Array        var::VariantType_Array::instance;
 const var::VariantType_Binary       var::VariantType_Binary::instance;
 const var::VariantType_Method       var::VariantType_Method::instance;
-
 
 //==============================================================================
 var::var() noexcept : type (&VariantType_Void::instance) {}

--- a/modules/juce_core/containers/juce_Variant.cpp
+++ b/modules/juce_core/containers/juce_Variant.cpp
@@ -399,6 +399,9 @@ public:
     VariantType_Method() noexcept {}
     static const VariantType_Method instance;
 
+    void cleanUp (ValueUnion& data) const noexcept override                      { delete data.methodValue; }
+    void createCopy (ValueUnion& dest, const ValueUnion& source) const override  { dest.methodValue = new NativeFunction (*source.methodValue); }
+
     String toString (const ValueUnion&) const override               { return "Method"; }
     bool toBool (const ValueUnion& data) const noexcept override     { return data.methodValue != nullptr; }
     bool isMethod() const noexcept override                          { return true; }
@@ -446,7 +449,7 @@ var::var (const int v) noexcept       : type (&VariantType_Int::instance)    { v
 var::var (const int64 v) noexcept     : type (&VariantType_Int64::instance)  { value.int64Value = v; }
 var::var (const bool v) noexcept      : type (&VariantType_Bool::instance)   { value.boolValue = v; }
 var::var (const double v) noexcept    : type (&VariantType_Double::instance) { value.doubleValue = v; }
-var::var (NativeFunction m) noexcept  : type (&VariantType_Method::instance) { value.methodValue = m; }
+var::var (NativeFunction m) noexcept  : type (&VariantType_Method::instance) { value.methodValue = new NativeFunction (m); }
 var::var (const Array<var>& v)        : type (&VariantType_Array::instance)  { value.objectValue = new VariantType_Array::RefCountedArray(v); }
 var::var (const String& v)            : type (&VariantType_String::instance) { new (value.stringValue) String (v); }
 var::var (const char* const v)        : type (&VariantType_String::instance) { new (value.stringValue) String (v); }
@@ -599,7 +602,7 @@ var var::getProperty (const Identifier& propertyName, const var& defaultReturnVa
 
 var::NativeFunction var::getNativeFunction() const
 {
-    return isMethod() ? value.methodValue : nullptr;
+    return (isMethod() && value.methodValue != nullptr) ? *value.methodValue : nullptr;
 }
 
 var var::invoke (const Identifier& method, const var* arguments, int numArguments) const

--- a/modules/juce_core/containers/juce_Variant.h
+++ b/modules/juce_core/containers/juce_Variant.h
@@ -61,7 +61,11 @@ public:
         JUCE_DECLARE_NON_COPYABLE (NativeFunctionArgs)
     };
 
+   #if JUCE_COMPILER_SUPPORTS_LAMBDAS
+    typedef std::function<var (const NativeFunctionArgs&)> NativeFunction;
+   #else
     typedef var (*NativeFunction) (const NativeFunctionArgs&);
+   #endif
 
     //==============================================================================
     /** Creates a void variant. */
@@ -303,7 +307,7 @@ private:
         char stringValue [sizeof (String)];
         ReferenceCountedObject* objectValue;
         MemoryBlock* binaryValue;
-        NativeFunction methodValue;
+        NativeFunction* methodValue;
     };
 
     const VariantType* type;


### PR DESCRIPTION
Only if we have a c++11 compiler. Should work ok in older compilers but obviously they will not support using lambdas.
