### PR TITLE
fix typos in juce_gui_basics.h and juce_StringArray.h documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ profile
 **/MacOSX/build
 **/iOS/build
 **/Linux/build
+**/LinuxMakefile/build
 **/VisualStudio2005/Debug
 **/VisualStudio2005/Release
 **/VisualStudio2008/Debug


### PR DESCRIPTION
juce_gui_basics.h:
it looks like the last sentence of the doc comment was copied from the JUCE_USE_XRANDR doc above it

juce_StringArray.h
doc comment was identical to the whitespace tokenizer method - replaced with the analogous addTokens() doc comment