### PR TITLE
* add handling of '.' to juce::File::removeEllipsis

### DIFF
--- a/modules/juce_core/files/juce_File.cpp
+++ b/modules/juce_core/files/juce_File.cpp
@@ -78,11 +78,15 @@ static String removeEllipsis (const String& path)
 
     for (int i = 1; i < toks.size(); ++i)
     {
-        if (toks[i] == ".." && toks[i - 1] != "..")
+        if (toks[i] == ".." && toks[i - 1] != "..") // 'pop' previous token
         {
             toks.removeRange (i - 1, 2);
             i = jmax (0, i - 2);
         }
+		else if(toks[i] == "."){ // no op
+			toks.removeRange (i , 1);
+			i = jmax (0, i - 1);
+		}
     }
 
     return toks.joinIntoString (File::separatorString);


### PR DESCRIPTION
Added handling of single '.' to File::removeEllipsis() in direct response to [bug] incorrect handling of: 
>"C:\Dir1\Dir2\Dir3\Dir4\\.\\..\\..\DirA"

resolving to:
> "C:\Dir1\Dir2\Dir3\DirA"

instead of:
> "C:\Dir1\Dir2\DirA"

When running this code:
`juce::File::getSpecialLocation(juce::File::currentExecutableFile).getParentDirectory().setAsCurrentWorkingDirectory();`