### PR TITLE
Fix colour for toggled button in LookAndFeelV3

### DIFF
--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V3.cpp
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V3.cpp
@@ -28,7 +28,6 @@ LookAndFeel_V3::LookAndFeel_V3()
 
     const Colour textButtonColour (0xffeeeeff);
     setColour (TextButton::buttonColourId, textButtonColour);
-    setColour (TextButton::buttonOnColourId, textButtonColour);
     setColour (ComboBox::buttonColourId, textButtonColour);
     setColour (TextEditor::outlineColourId, Colours::transparentBlack);
     setColour (TabbedButtonBar::tabOutlineColourId, Colour (0x66000000));


### PR DESCRIPTION
The monster commit 70949aa changed `juce_LookAndFeel_V3.cpp` to set `textButtonColour` for `TextButton::buttonOnColourId`, which is also used for `TextButton::buttonColourId`. This makes it impossible to distinguish the toggle state of buttons. Simply removing the line restores the previous behavior.