### PR TITLE
update active ports on opening JACK audio devices

### DIFF
--- a/modules/juce_audio_devices/native/juce_linux_JackAudio.cpp
+++ b/modules/juce_audio_devices/native/juce_linux_JackAudio.cpp
@@ -290,6 +290,8 @@ public:
             }
         }
 
+        updateActivePorts();
+
         return lastError;
     }
 


### PR DESCRIPTION
This fixes the issue that plug-in standalones based on StandaloneFilterApp run prepareToPlay() too early or more often than necessary and possibly with a wrong channel count (including the fatal condition of zero input channels).

--

After a bit of debugging I found that the JACK audio device is opened before the ports have been fully scanned (probably due to a callback):

```
JUCE v4.2.2

   AudioDeviceManager::setAudioDeviceSetup()
   AudioDeviceManager::setAudioDeviceSetup() --> opening audio device
   JackAudioIODevice::updateActivePorts()
      updating output port #1
   AudioDeviceManager::setAudioDeviceSetup() --> starting audio device
[Squeezer] preparing to play
[Squeezer] number of input channels: 0
[Squeezer] number of output channels: 0
JUCE Assertion failure in compressor.cpp:43
      updating output port #2
      updating output port #3
      updating output [...]
      updating input port #1
      updating input port #2
      updating input port #3
      updating input [...]
[Squeezer] releasing resources

[Squeezer] preparing to play
[Squeezer] number of input channels: 2
[Squeezer] number of output channels: 2
   JackAudioIODevice::updateActivePorts()
      updating output port #1
      updating output port #2
      updating output port #3
      updating output [...]
      updating input port #1
      updating input port #2
      updating input port #3
      updating input [...]
   JackAudioIODevice::updateActivePorts()
      updating output port #1
      updating output port #2
      updating output port #3
      updating output [...]
      updating input port #1
      updating input port #2
      updating input port #3
      updating input [...]
   JackAudioIODevice::updateActivePorts()
      updating output port #1
      updating output port #2
      updating output port #3
      updating output [...]
      updating input port #1
      updating input port #2
      updating input port #3
      updating input [...]
   JackAudioIODevice::updateActivePorts()
      updating output port #1
      updating output port #2
      updating output port #3
      updating output [...]
      updating input port #1
      updating input port #2
      updating input port #3
      updating input [...]
   JackAudioIODevice::updateActivePorts()
      updating output port #1
      updating output port #2
      updating output port #3
      updating output [...]
      updating input port #1
      updating input port #2
      updating input port #3
      updating input [...]
[Squeezer] releasing resources

```
Note that the plug-in is initialised with **zero** input channels! This is ugly and might be hard to handle, depending on the situation.

Inserting an explicit call to `updateActivePorts()` as suggested in the pull request fixes the problem for both the deprecated and the new channel layout system:
```
JUCE v4.2.2

   AudioDeviceManager::setAudioDeviceSetup()
   AudioDeviceManager::setAudioDeviceSetup() --> opening audio device
   JackAudioIODevice::updateActivePorts()
      updating output port #1
   JackAudioIODevice::updateActivePorts()
      updating output port #1
      updating output port #2
      updating output port #3
      updating output [...]
      updating input port #1
      updating input port #2
      updating input port #3
      updating input [...]
   JackAudioIODevice::updateActivePorts()
      updating output port #1
      updating output port #2
      updating output port #3
      updating output [...]
      updating input port #1
      updating input port #2
      updating input port #3
      updating input [...]
   JackAudioIODevice::updateActivePorts()
      updating output port #1
      updating output port #2
      updating output port #3
      updating output [...]
      updating input port #1
      updating input port #2
      updating input port #3
      updating input [...]
   JackAudioIODevice::updateActivePorts()
      updating output port #1
      updating output port #2
      updating output port #3
      updating output [...]
      updating input port #1
      updating input port #2
      updating input port #3
      updating input [...]
      updating output port #2
      updating output port #3
      updating output [...]
      updating input port #1
      updating input port #2
      updating input port #3
      updating input [...]
   AudioDeviceManager::setAudioDeviceSetup() --> starting audio device
[Squeezer] preparing to play
[Squeezer] number of input channels: 2
[Squeezer] number of output channels: 2
   JackAudioIODevice::updateActivePorts()
      updating output port #1
      updating output port #2
      updating output port #3
      updating output [...]
      updating input port #1
      updating input port #2
      updating input port #3
      updating input [...]
   JackAudioIODevice::updateActivePorts()
      updating output port #1
      updating output port #2
      updating output port #3
      updating output [...]
      updating input port #1
      updating input port #2
      updating input port #3
      updating input [...]
[Squeezer] releasing resources

```
Martin