### PR TITLE
enable subclassing of StandaloneFilterApp

### DIFF
--- a/modules/juce_audio_plugin_client/Standalone/juce_StandaloneFilterApp.cpp
+++ b/modules/juce_audio_plugin_client/Standalone/juce_StandaloneFilterApp.cpp
@@ -91,10 +91,8 @@ public:
         quit();
     }
 
-private:
+protected:
     ScopedPointer<StandaloneFilterWindow> mainWindow;
 };
-
-START_JUCE_APPLICATION (StandaloneFilterApp);
 
 #endif

--- a/modules/juce_audio_plugin_client/juce_audio_plugin_client_Standalone.cpp
+++ b/modules/juce_audio_plugin_client/juce_audio_plugin_client_Standalone.cpp
@@ -27,3 +27,5 @@
 #endif
 
 #include "Standalone/juce_StandaloneFilterApp.cpp"
+
+START_JUCE_APPLICATION (StandaloneFilterApp);


### PR DESCRIPTION
Include `<juce_audio_plugin_client/Standalone/juce_StandaloneFilterApp.cpp>` for subclassing `StandaloneFilterApp`, while including `<juce_audio_plugin_client/juce_audio_plugin_client_Standalone.cpp>` gives the old behaviour.

See https://forum.juce.com/t/standalonefilterapp-create-the-standalonefilterwindow-with-a-transparent-colour/17287 (second and third post)...