### PR TITLE
Fixed the code that determines the modifier masks on Linux.

### DIFF
--- a/modules/juce_gui_basics/native/juce_linux_Windowing.cpp
+++ b/modules/juce_gui_basics/native/juce_linux_Windowing.cpp
@@ -2769,14 +2769,22 @@ private:
         Keys::AltMask = 0;
         Keys::NumLockMask = 0;
 
+        // Map contains 8 * max_keypermod entries, one for each modifier key.
+        // Modifier keys (and mask) in order are: 
+        //  shift, lock, control, mod1, mod2, mod3, mod4, mod5
         if (XModifierKeymap* const mapping = XGetModifierMapping (display))
         {
             for (int i = 0; i < 8; i++)
             {
-                if (mapping->modifiermap [i << 1] == altLeftCode)
-                    Keys::AltMask = 1 << i;
-                else if (mapping->modifiermap [i << 1] == numLockCode)
-                    Keys::NumLockMask = 1 << i;
+                for (int j = 0; j<mapping->max_keypermod; ++j)
+                {
+                    const int mapIndex = i * mapping->max_keypermod + j;
+
+                    if (mapping->modifiermap[mapIndex] == altLeftCode)
+                        Keys::AltMask = 1 << i;
+                    else if (mapping->modifiermap[mapIndex] == numLockCode)
+                        Keys::NumLockMask = 1 << i;
+                }
             }
 
             XFreeModifiermap (mapping);


### PR DESCRIPTION
The code that determines the modifier masks on Linux is broken. My patch fixes that. The old code seemed to assume that the modifiermap always has 2 entries per modifier key (i.e. max_keypermod == 2). That's an invalid assertion and max_keypermod should be used instead.

This is also discussed in the JUCE forum:
https://forum.juce.com/t/alt-key-not-working-on-linux/15830?u=tloockx
