### PR TITLE
Add window property to JuceAppStartupDelegate

### DIFF
--- a/modules/juce_gui_basics/native/juce_ios_Windowing.mm
+++ b/modules/juce_gui_basics/native/juce_ios_Windowing.mm
@@ -39,6 +39,8 @@ Array<AppInactivityCallback*> appBecomingInactiveCallbacks;
 {
 }
 
+@property (strong, nonatomic) UIWindow *window;
+
 - (void) applicationDidFinishLaunching: (UIApplication*) application;
 - (void) applicationWillTerminate: (UIApplication*) application;
 - (void) applicationDidEnterBackground: (UIApplication*) application;


### PR DESCRIPTION
In order to be able to use certain iOS libraries that expect a `window` property in the `UIApplication` instance, we need this to be declared in `JuceAppStartupDelegate`. 

We can then set it up as follows
```Objective-C
NSObject<UIApplicationDelegate> *appDelegate = [[UIApplication sharedApplication] delegate];
appDelegate.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
appDelegate.window.backgroundColor = [UIColor blackColor];
```