### PR TITLE
Improve graph editor panel in audio plugin host

### DIFF
--- a/examples/audio plugin host/Source/GraphEditorPanel.cpp
+++ b/examples/audio plugin host/Source/GraphEditorPanel.cpp
@@ -176,8 +176,11 @@ PluginWindow* PluginWindow::getWindowFor (AudioProcessorGraph::Node* const node,
 
     if (ui == nullptr)
     {
-        if (type == Generic || type == Parameters)
-            ui = new GenericAudioProcessorEditor (processor);
+		if (type == Generic || type == Parameters) {
+			// create generic UI only if there are parameters
+			if (processor->getNumParameters())
+				ui = new GenericAudioProcessorEditor(processor);
+		}
         else if (type == Programs)
             ui = new ProgramAudioProcessorEditor (processor);
     }

--- a/examples/audio plugin host/Source/GraphEditorPanel.cpp
+++ b/examples/audio plugin host/Source/GraphEditorPanel.cpp
@@ -176,11 +176,11 @@ PluginWindow* PluginWindow::getWindowFor (AudioProcessorGraph::Node* const node,
 
     if (ui == nullptr)
     {
-		if (type == Generic || type == Parameters) {
-			// create generic UI only if there are parameters
-			if (processor->getNumParameters())
-				ui = new GenericAudioProcessorEditor(processor);
-		}
+        if (type == Generic || type == Parameters) {
+            // create generic UI only if there are parameters
+            if (processor->getNumParameters())
+                ui = new GenericAudioProcessorEditor(processor);
+        }
         else if (type == Programs)
             ui = new ProgramAudioProcessorEditor (processor);
     }


### PR DESCRIPTION
## a very slight improvement for the audio plugin host demo:
- Currently, if you double-click a plugin with no parameters, an empty dialog appears.
  - E.g. try the internal plugins audio in/out and midi in/out.
- With the change, a plugin without UI and without parameters will not open up any dialog.
