### PR TITLE
changed MidiMessageSequence::getIndexOf() parameter to const

### DIFF
--- a/modules/juce_audio_basics/midi/juce_MidiMessageSequence.cpp
+++ b/modules/juce_audio_basics/midi/juce_MidiMessageSequence.cpp
@@ -80,7 +80,7 @@ int MidiMessageSequence::getIndexOfMatchingKeyUp (const int index) const noexcep
     return -1;
 }
 
-int MidiMessageSequence::getIndexOf (MidiEventHolder* const event) const noexcept
+int MidiMessageSequence::getIndexOf (const MidiEventHolder* const event) const noexcept
 {
     return list.indexOf (event);
 }

--- a/modules/juce_audio_basics/midi/juce_MidiMessageSequence.h
+++ b/modules/juce_audio_basics/midi/juce_MidiMessageSequence.h
@@ -121,7 +121,7 @@ public:
     int getIndexOfMatchingKeyUp (int index) const noexcept;
 
     /** Returns the index of an event. */
-    int getIndexOf (MidiEventHolder* event) const noexcept;
+    int getIndexOf (const MidiEventHolder* event) const noexcept;
 
     /** Returns the index of the first event on or after the given timestamp.
         If the time is beyond the end of the sequence, this will return the


### PR DESCRIPTION
Looks like OwnedArray::indexOf() accept const parameter as well, so that should not be a problem.