### PR TITLE
Projucer AndroidStudioExporter extra fields

### DIFF
--- a/extras/Projucer/Source/Project Saving/jucer_ProjectExport_AndroidBase.h
+++ b/extras/Projucer/Source/Project Saving/jucer_ProjectExport_AndroidBase.h
@@ -182,6 +182,9 @@ public:
     {
         props.add (new TextPropertyComponent (androidTheme.getPropertyAsValue(), "Android Theme", 256, false),
                    "E.g. @android:style/Theme.NoTitleBar or leave blank for default");
+        
+        props.add (new TextPropertyComponent (androidApplicationClass.getPropertyAsValue(), "Android Application Class", 256, false),
+                   "The name of your Application class, if your project extends it");
     }
 
     //==============================================================================

--- a/extras/Projucer/Source/Project Saving/jucer_ProjectExport_AndroidBase.h
+++ b/extras/Projucer/Source/Project Saving/jucer_ProjectExport_AndroidBase.h
@@ -31,9 +31,12 @@ public:
           androidScreenOrientation (settings, Ids::androidScreenOrientation, nullptr, "unspecified"),
           androidActivityClass (settings, Ids::androidActivityClass, nullptr, createDefaultClassName()),
           androidActivitySubClassName (settings, Ids::androidActivitySubClassName, nullptr),
+          androidApplicationClass (settings, Ids::androidApplicationClass, nullptr),
           androidVersionCode (settings, Ids::androidVersionCode, nullptr, "1"),
-          androidMinimumSDK (settings, Ids::androidMinimumSDK, nullptr, "23"),
           androidTheme (settings, Ids::androidTheme, nullptr),
+          androidMinimumSDK (settings, Ids::androidMinimumSDK, nullptr, "23"),
+          androidCompileSDK (settings, Ids::androidCompileSDK, nullptr, "23"),
+          androidTargetSDK (settings, Ids::androidTargetSDK, nullptr, "23"),
           androidInternetNeeded (settings, Ids::androidInternetNeeded, nullptr, true),
           androidMicNeeded (settings, Ids::microphonePermissionNeeded, nullptr, false),
           androidBluetoothNeeded (settings, Ids::androidBluetoothNeeded, nullptr, true),
@@ -103,7 +106,8 @@ public:
 
     //==============================================================================
     CachedValue<String> androidScreenOrientation, androidActivityClass, androidActivitySubClassName,
-                        androidVersionCode, androidMinimumSDK, androidTheme;
+                        androidApplicationClass, androidVersionCode, androidTheme,
+                        androidMinimumSDK, androidCompileSDK, androidTargetSDK;
 
     CachedValue<bool>   androidInternetNeeded, androidMicNeeded, androidBluetoothNeeded;
     CachedValue<String> androidOtherPermissions;
@@ -137,6 +141,12 @@ public:
 
         props.add (new TextWithDefaultPropertyComponent<String> (androidMinimumSDK, "Minimum SDK version", 32),
                    "The number of the minimum version of the Android SDK that the app requires");
+        
+        props.add (new TextWithDefaultPropertyComponent<String> (androidCompileSDK, "Compile SDK version", 32),
+                   "The version of the Android SDK to compile your app with (use latest version)");
+        
+        props.add (new TextWithDefaultPropertyComponent<String> (androidTargetSDK, "Target SDK version", 32),
+                   "The API Level that the application targets");
     }
 
     //==============================================================================
@@ -178,7 +188,7 @@ public:
     }
 
     //==============================================================================
-    void createOtherExporterProperties (PropertyListBuilder& props)
+    virtual void createOtherExporterProperties (PropertyListBuilder& props)
     {
         props.add (new TextPropertyComponent (androidTheme.getPropertyAsValue(), "Android Theme", 256, false),
                    "E.g. @android:style/Theme.NoTitleBar or leave blank for default");
@@ -427,7 +437,7 @@ public:
 
         XmlElement* sdk = manifest->createNewChildElement ("uses-sdk");
         sdk->setAttribute ("android:minSdkVersion", androidMinimumSDK.get());
-        sdk->setAttribute ("android:targetSdkVersion", androidMinimumSDK.get());
+        sdk->setAttribute ("android:targetSdkVersion", androidTargetSDK.get());
 
         {
             const StringArray permissions (getPermissionsRequired());
@@ -445,6 +455,9 @@ public:
 
         XmlElement* app = manifest->createNewChildElement ("application");
         app->setAttribute ("android:label", "@string/app_name");
+        
+        if (androidApplicationClass.get().isNotEmpty())
+            app->setAttribute ("android:name", androidApplicationClass.get());
 
         if (androidTheme.get().isNotEmpty())
             app->setAttribute ("android:theme", androidTheme.get());

--- a/extras/Projucer/Source/Project Saving/jucer_ProjectExport_AndroidStudio.h
+++ b/extras/Projucer/Source/Project Saving/jucer_ProjectExport_AndroidStudio.h
@@ -569,7 +569,8 @@ private:
         model.addChildObject (getAndroidBuildConfigs());
         model.addChildObject (getAndroidSigningConfigs());
         model.addChildObject (getAndroidProductFlavours());
-        model.addChildObject (getAndroidPackagingOptions());
+        if (getPackagingOptionsString().isNotEmpty())
+            model.addChildObject (getAndroidPackagingOptions());
 
         return model.toString();
     }

--- a/extras/Projucer/Source/Project Saving/jucer_ProjectExport_AndroidStudio.h
+++ b/extras/Projucer/Source/Project Saving/jucer_ProjectExport_AndroidStudio.h
@@ -35,7 +35,7 @@ public:
 
     static const char* getName()                         { return "Android Studio"; }
     static const char* getValueTreeTypeName()            { return "ANDROIDSTUDIO"; }
-    
+
     //==============================================================================
     Value  getPackagingOptionsValue()                { return getSetting (Ids::androidPackagingOptions); }
     String getPackagingOptionsString() const         { return settings [Ids::androidPackagingOptions]; }
@@ -577,7 +577,12 @@ private:
     String getAppDependencies() const
     {
         GradleObject dependencies ("dependencies");
-        dependencies.add<GradleStatement> ("compile \"com.android.support:support-v4:+\"");
+        StringArray dependencyTokens;
+        dependencyTokens.addTokens (gradleAppDependencies.get(), "\n", "");
+        for (auto dependency : dependencyTokens)
+        {
+            dependencies.add<GradleStatement> (dependency);
+        }
         return dependencies.toString();
     }
 
@@ -586,7 +591,7 @@ private:
     {
         auto android = new GradleObject ("android");
 
-        android->add<GradleValue> ("compileSdkVersion", androidMinimumSDK.get().getIntValue());
+        android->add<GradleValue> ("compileSdkVersion", androidCompileSDK.get().getIntValue());
         android->add<GradleString> ("buildToolsVersion", buildToolsVersion.get());
         android->addChildObject (getAndroidDefaultConfig());
 
@@ -597,12 +602,13 @@ private:
     {
         const String bundleIdentifier  = project.getBundleIdentifier().toString().toLowerCase();
         const int minSdkVersion = androidMinimumSDK.get().getIntValue();
+        const int targetSdkVersion = androidTargetSDK.get().getIntValue();
 
         auto defaultConfig = new GradleObject ("defaultConfig.with");
 
         defaultConfig->add<GradleString> ("applicationId",             bundleIdentifier);
         defaultConfig->add<GradleValue>  ("minSdkVersion.apiLevel",    minSdkVersion);
-        defaultConfig->add<GradleValue>  ("targetSdkVersion.apiLevel", minSdkVersion);
+        defaultConfig->add<GradleValue>  ("targetSdkVersion.apiLevel", targetSdkVersion);
 
         return defaultConfig;
     }

--- a/extras/Projucer/Source/Project Saving/jucer_ProjectExport_AndroidStudio.h
+++ b/extras/Projucer/Source/Project Saving/jucer_ProjectExport_AndroidStudio.h
@@ -35,7 +35,11 @@ public:
 
     static const char* getName()                         { return "Android Studio"; }
     static const char* getValueTreeTypeName()            { return "ANDROIDSTUDIO"; }
-
+    
+    //==============================================================================
+    Value  getPackagingOptionsValue()                { return getSetting (Ids::androidPackagingOptions); }
+    String getPackagingOptionsString() const         { return settings [Ids::androidPackagingOptions]; }
+    
     static AndroidStudioProjectExporter* createForSettings (Project& project, const ValueTree& settings)
     {
         if (settings.hasType (getValueTreeTypeName()))
@@ -98,6 +102,9 @@ public:
         
         props.add (new TextWithDefaultPropertyComponent<String> (gradleRepositories, "gradle project repositories", 8192, true),
                    "Declare the repositories for your project dependencies (build.gradle)");
+        
+        props.add (new TextPropertyComponent (getPackagingOptionsValue(), "packaging options", 8192, true),
+                   "DSL object for configuring APK packaging options");
     }
                                                                             
     
@@ -562,6 +569,7 @@ private:
         model.addChildObject (getAndroidBuildConfigs());
         model.addChildObject (getAndroidSigningConfigs());
         model.addChildObject (getAndroidProductFlavours());
+        model.addChildObject (getAndroidPackagingOptions());
 
         return model.toString();
     }
@@ -827,6 +835,22 @@ private:
         flavour->add<GradleStatement> ("ndk.abiFilters.add(\"" + arch + "\")");
         return flavour;
     }
+            
+            
+    GradleObject* getAndroidPackagingOptions() const
+    {
+        auto packagingOptions = new GradleObject ("android.packagingOptions");
+        
+        StringArray packagingOptionLines;
+        packagingOptionLines.addTokens (getPackagingOptionsString(), "\n", "");
+        for (auto packagingOption : packagingOptionLines)
+        {
+            packagingOptions->add<GradleStatement> (packagingOption);
+        }
+
+        return packagingOptions;
+    }
+            
     //==============================================================================
     String getLocalPropertiesFileContent() const
     {

--- a/extras/Projucer/Source/Project Saving/jucer_TextWithDefaultPropertyComponent.h
+++ b/extras/Projucer/Source/Project Saving/jucer_TextWithDefaultPropertyComponent.h
@@ -35,8 +35,9 @@ class TextWithDefaultPropertyComponent  : public PropertyComponent,
                        public FileDragAndDropTarget
     {
     public:
-        LabelComp (TextWithDefaultPropertyComponent& tpc, const int charLimit)
+        LabelComp (TextWithDefaultPropertyComponent& tpc, const int charLimit, bool multiLine)
             : Label (String(), String()),
+              isMultiLine (multiLine),
               owner (tpc),
               maxChars (charLimit)
         {

--- a/extras/Projucer/Source/Project Saving/jucer_TextWithDefaultPropertyComponent.h
+++ b/extras/Projucer/Source/Project Saving/jucer_TextWithDefaultPropertyComponent.h
@@ -61,6 +61,7 @@ class TextWithDefaultPropertyComponent  : public PropertyComponent,
         {
             TextEditor* const ed = Label::createEditorComponent();
             ed->setInputRestrictions (maxChars);
+            ed->setMultiLine (isMultiLine);
             return ed;
         }
 
@@ -76,6 +77,8 @@ class TextWithDefaultPropertyComponent  : public PropertyComponent,
             setColour (textColourId,       owner.findColour (TextWithDefaultPropertyComponent::textColourId));
             repaint();
         }
+        
+        bool isMultiLine;
 
     private:
         TextWithDefaultPropertyComponent& owner;
@@ -84,19 +87,19 @@ class TextWithDefaultPropertyComponent  : public PropertyComponent,
 
 protected:
     //==========================================================================
-    TextWithDefaultPropertyComponent (const String& propertyName, int maxNumChars)
+    TextWithDefaultPropertyComponent (const String& propertyName, int maxNumChars, bool isMultiLine = false)
         : PropertyComponent (propertyName)
     {
-        createEditor (maxNumChars);
+        createEditor (maxNumChars, isMultiLine);
     }
 
 public:
     //==========================================================================
-    TextWithDefaultPropertyComponent (CachedValue<Type>& valueToControl, const String& propertyName, int maxNumChars)
+    TextWithDefaultPropertyComponent (CachedValue<Type>& valueToControl, const String& propertyName, int maxNumChars, bool isMultiLine = false)
         : PropertyComponent (propertyName),
           cachedValue (valueToControl)
     {
-        createEditor (maxNumChars);
+        createEditor (maxNumChars, isMultiLine);
         refresh();
     }
 
@@ -148,9 +151,15 @@ private:
 
     ScopedPointer<LabelComp> textEditor;
 
-    void createEditor (int maxNumChars)
+    void createEditor (int maxNumChars, bool isMultiLine)
     {
-        addAndMakeVisible (textEditor = new LabelComp (*this, maxNumChars));
+        addAndMakeVisible (textEditor = new LabelComp (*this, maxNumChars, isMultiLine));
+        
+        if (isMultiLine)
+        {
+            textEditor->setJustificationType (Justification::topLeft);
+            preferredHeight = 100;
+        }
     }
 
     void labelTextChanged (Label*) override {}
@@ -158,7 +167,11 @@ private:
     void editorShown (Label*, TextEditor& editor) override
     {
         if (cachedValue.isUsingDefault())
-            editor.setText (String(), dontSendNotification);
+        {
+            // Keep default value if this is a mult-line field
+            String initialValue = textEditor->isMultiLine ? getText() : String();
+            editor.setText (initialValue, dontSendNotification);
+        }
     }
 
     void editorHidden (Label*, TextEditor&) override {}

--- a/extras/Projucer/Source/Utility/jucer_PresetIDs.h
+++ b/extras/Projucer/Source/Utility/jucer_PresetIDs.h
@@ -181,6 +181,7 @@ namespace Ids
     DECLARE_ID (gradleToolchainVersion);
     DECLARE_ID (gradleAppDependencies);
     DECLARE_ID (gradleSettings);
+    DECLARE_ID (gradleRepositories);
     DECLARE_ID (linuxExtraPkgConfig);
     DECLARE_ID (font);
     DECLARE_ID (colour);

--- a/extras/Projucer/Source/Utility/jucer_PresetIDs.h
+++ b/extras/Projucer/Source/Utility/jucer_PresetIDs.h
@@ -150,6 +150,7 @@ namespace Ids
     DECLARE_ID (microphonePermissionNeeded);
     DECLARE_ID (androidActivityClass);
     DECLARE_ID (androidActivitySubClassName);
+    DECLARE_ID (androidApplicationClass);
     DECLARE_ID (androidVersionCode);
     DECLARE_ID (androidSDKPath);
     DECLARE_ID (androidNDKPath);
@@ -157,6 +158,8 @@ namespace Ids
     DECLARE_ID (androidArchitectures);
     DECLARE_ID (androidBluetoothNeeded);
     DECLARE_ID (androidMinimumSDK);
+    DECLARE_ID (androidCompileSDK);
+    DECLARE_ID (androidTargetSDK);
     DECLARE_ID (androidOtherPermissions);
     DECLARE_ID (androidKeyStore);
     DECLARE_ID (androidKeyStorePass);
@@ -176,6 +179,8 @@ namespace Ids
     DECLARE_ID (gradleWrapperVersion);
     DECLARE_ID (gradleToolchain);
     DECLARE_ID (gradleToolchainVersion);
+    DECLARE_ID (gradleAppDependencies);
+    DECLARE_ID (gradleSettings);
     DECLARE_ID (linuxExtraPkgConfig);
     DECLARE_ID (font);
     DECLARE_ID (colour);

--- a/extras/Projucer/Source/Utility/jucer_PresetIDs.h
+++ b/extras/Projucer/Source/Utility/jucer_PresetIDs.h
@@ -169,6 +169,7 @@ namespace Ids
     DECLARE_ID (androidStaticLibraries);
     DECLARE_ID (androidSharedLibraries);
     DECLARE_ID (androidScreenOrientation);
+    DECLARE_ID (androidPackagingOptions);
     DECLARE_ID (iosScreenOrientation);
     DECLARE_ID (iosInAppPurchases);
     DECLARE_ID (iosBackgroundAudio);


### PR DESCRIPTION
Projucer changes for AndroidStudio:
- Application class name 
- repositories (Project build.gradle)
- dependencies (app build.gradle)
- separate compile, target and minSdkVersion
- settings.gradle
- android.packagingOptions
