### PR TITLE
Some fixes from the Debian packaging of juce

### DIFF
--- a/extras/Projucer/Source/Application/jucer_Application.cpp
+++ b/extras/Projucer/Source/Application/jucer_Application.cpp
@@ -130,6 +130,9 @@ void ProjucerApplication::initialiseBasics()
     icons = new Icons();
 }
 
+#ifndef BUILD_DATE
+# define BUILD_DATE __DATE__
+#endif
 bool ProjucerApplication::initialiseLogger (const char* filePrefix)
 {
     if (logger == nullptr)
@@ -142,7 +145,7 @@ bool ProjucerApplication::initialiseLogger (const char* filePrefix)
 
         logger = FileLogger::createDateStampedLogger (folder, filePrefix, ".txt",
                                                       getApplicationName() + " " + getApplicationVersion()
-                                                        + "  ---  Build date: " __DATE__);
+                                                        + "  ---  Build date: " BUILD_DATE);
         Logger::setCurrentLogger (logger);
     }
 

--- a/extras/Projucer/Source/Project Saving/jucer_ProjectExport_Make.h
+++ b/extras/Projucer/Source/Project Saving/jucer_ProjectExport_Make.h
@@ -228,12 +228,13 @@ private:
         out << "  JUCE_CPPFLAGS := $(DEPFLAGS)";
         writeDefineFlags (out, config);
         writeHeaderPathFlags (out, config);
-        out << newLine;
+        out << " $(CPPFLAGS)"
+            << newLine;
     }
 
     void writeLinkerFlags (OutputStream& out, const BuildConfiguration& config) const
     {
-        out << "  JUCE_LDFLAGS += $(LDFLAGS) $(TARGET_ARCH) -L$(JUCE_BINDIR) -L$(JUCE_LIBDIR)";
+        out << "  JUCE_LDFLAGS += $(TARGET_ARCH) -L$(JUCE_BINDIR) -L$(JUCE_LIBDIR)";
 
         {
             StringArray flags (makefileExtraLinkerFlags);
@@ -277,7 +278,9 @@ private:
         if (libraries.size() != 0)
             out << " -l" << replacePreprocessorTokens (config, libraries.joinIntoString (" -l")).trim();
 
-        out << " " << replacePreprocessorTokens (config, getExtraLinkerFlagsString()).trim()
+        out << " " << replacePreprocessorTokens (config, getExtraLinkerFlagsString()).trim();
+
+        out << " $(LDFLAGS)"
             << newLine;
     }
 
@@ -306,7 +309,7 @@ private:
 
         writeCppFlags (out, config);
 
-        out << "  JUCE_CFLAGS += $(CFLAGS) $(JUCE_CPPFLAGS) $(TARGET_ARCH)";
+        out << "  JUCE_CFLAGS += $(JUCE_CPPFLAGS) $(TARGET_ARCH)";
 
         if (config.isDebug())
             out << " -g -ggdb";
@@ -316,6 +319,7 @@ private:
 
         out << " -O" << config.getGCCOptimisationFlag()
             << (" "  + replacePreprocessorTokens (config, getExtraCompilerFlagsString())).trimEnd()
+            out << " $(CFLAGS)"
             << newLine;
 
         String cppStandardToUse (getCppStandardString());
@@ -323,8 +327,9 @@ private:
         if (cppStandardToUse.isEmpty())
             cppStandardToUse = "-std=c++11";
 
-        out << "  JUCE_CXXFLAGS += $(CXXFLAGS) $(JUCE_CFLAGS) "
+        out << "  JUCE_CXXFLAGS += $(JUCE_CFLAGS) "
             << cppStandardToUse
+            out << " $(CXXFLAGS)"
             << newLine;
 
         writeLinkerFlags (out, config);

--- a/extras/Projucer/Source/Project Saving/jucer_ProjectExport_Make.h
+++ b/extras/Projucer/Source/Project Saving/jucer_ProjectExport_Make.h
@@ -372,6 +372,15 @@ private:
             << "# Don't edit this file! Your changes will be overwritten when you re-save the Projucer project!" << newLine
             << newLine;
 
+        out << "# build with \"V=1\" for verbose builds" << newLine
+            << "ifeq ($(V), 1)" << newLine
+            << "V_AT =" << newLine
+            << "else" << newLine
+            << "V_AT = @" << newLine
+            << "endif" << newLine
+            << newLine;
+
+
         out << "# (this disables dependency generation if multiple architectures are set)" << newLine
             << "DEPFLAGS := $(if $(word 2, $(TARGET_ARCH)), , -MMD)" << newLine
             << newLine;
@@ -412,7 +421,7 @@ private:
             << "\t-@mkdir -p $(JUCE_BINDIR)" << newLine
             << "\t-@mkdir -p $(JUCE_LIBDIR)" << newLine
             << "\t-@mkdir -p $(JUCE_OUTDIR)" << newLine
-            << "\t@$(BLDCMD)" << newLine
+            << "\t$(V_AT)$(BLDCMD)" << newLine
             << newLine;
 
         if (useLinuxPackages)
@@ -434,7 +443,7 @@ private:
 
         out << "clean:" << newLine
             << "\t@echo Cleaning " << projectName << newLine
-            << "\t@$(CLEANCMD)" << newLine
+            << "\t$(V_AT)$(CLEANCMD)" << newLine
             << newLine;
 
         out << "strip:" << newLine
@@ -452,8 +461,8 @@ private:
                     << ": " << escapeSpaces (files.getReference(i).toUnixStyle()) << newLine
                     << "\t-@mkdir -p $(JUCE_OBJDIR)" << newLine
                     << "\t@echo \"Compiling " << files.getReference(i).getFileName() << "\"" << newLine
-                    << (files.getReference(i).hasFileExtension ("c;s;S") ? "\t@$(CC) $(JUCE_CFLAGS) -o \"$@\" -c \"$<\""
-                                                                         : "\t@$(CXX) $(JUCE_CXXFLAGS) -o \"$@\" -c \"$<\"")
+                    << (files.getReference(i).hasFileExtension ("c;s;S") ? "\t$(V_AT)$(CC) $(JUCE_CFLAGS) -o \"$@\" -c \"$<\""
+                                                                         : "\t$(V_AT)$(CXX) $(JUCE_CXXFLAGS) -o \"$@\" -c \"$<\"")
                     << newLine << newLine;
             }
         }

--- a/modules/juce_core/time/juce_Time.cpp
+++ b/modules/juce_core/time/juce_Time.cpp
@@ -598,14 +598,20 @@ static int getMonthNumberForCompileDate (const String& m) noexcept
     return 0;
 }
 
+#ifndef BUILD_DATE
+# define BUILD_DATE __DATE__
+#endif
+#ifndef BUILD_TIME
+# define BUILD_TIME __TIME__
+#endif
 Time Time::getCompilationDate()
 {
     StringArray dateTokens, timeTokens;
 
-    dateTokens.addTokens (__DATE__, true);
+    dateTokens.addTokens (BUILD_DATE, true);
     dateTokens.removeEmptyStrings (true);
 
-    timeTokens.addTokens (__TIME__, ":", StringRef());
+    timeTokens.addTokens (BUILD_TIME, ":", StringRef());
 
     return Time (dateTokens[2].getIntValue(),
                  getMonthNumberForCompileDate (dateTokens[0]),

--- a/modules/juce_core/zip/juce_GZIPDecompressorInputStream.cpp
+++ b/modules/juce_core/zip/juce_GZIPDecompressorInputStream.cpp
@@ -77,6 +77,7 @@ namespace zlibNamespace
   #endif
  #else
   #include JUCE_ZLIB_INCLUDE_PATH
+  #define z_uInt uInt
  #endif
 }
 

--- a/modules/juce_graphics/image_formats/juce_PNGLoader.cpp
+++ b/modules/juce_graphics/image_formats/juce_PNGLoader.cpp
@@ -320,7 +320,7 @@ namespace PNGHelpers
 
     static void JUCE_CDECL errorCallback (png_structp p, png_const_charp)
     {
-        longjmp (*(jmp_buf*) p->error_ptr, 1);
+        setjmp(png_jmpbuf(p));
     }
 
     static void JUCE_CDECL warningCallback (png_structp, png_const_charp) {}
@@ -442,8 +442,12 @@ namespace PNGHelpers
             for (size_t y = 0; y < height; ++y)
                 rows[y] = (png_bytep) (tempBuffer + lineStride * y);
 
+            png_bytep trans_alpha;
+            int num_trans;
+            png_color_16p trans_color;
+            png_get_tRNS(pngReadStruct, pngInfoStruct,  &trans_alpha, &num_trans, &trans_color);
             if (readImageData (pngReadStruct, pngInfoStruct, errorJumpBuf, rows))
-                return createImageFromData ((colorType & PNG_COLOR_MASK_ALPHA) != 0 || pngInfoStruct->num_trans > 0,
+                return createImageFromData ((colorType & PNG_COLOR_MASK_ALPHA) != 0 || num_trans,
                                             (int) width, (int) height, rows);
         }
 


### PR DESCRIPTION
here's a number of patches from the Debian  ['juce'](https://tracker.debian.org/pkg/juce) package.

# fix building with system-provided libraries
- the `z_uInt` and `png16` patches are needed to build juce without the bundled libraries.
  (please note that the `png16` patch has not really been tested against compatibility with older libpngs)

# CPP/C/CXX/LDFLAGS
it's great that juce now uses `JUCE_CFLAGS` (and similar) instead of `CFLAGS`.
it's even better that you include `CFLAGS`, so the build-process can inject additional flags.
however, it would be best if those flags were *appended* rather than *prepended*, as this would allow to override some of these FLAGS (provided the builder knows what they are doing).

e.g. if the builder policy is to build all packages with `-O0`, the usual way would be to run

    make CFLAGS="-O0"

however, since currently the CFLAGS are prepended,  this could expand to some actual compiler flags like `[...] -O0 [...] -fPIC -O3`, effectively disabling the builder's `-O0` flag (since later flags of the
 same kind will override earlier one, in this case `-O3` is used)

# silent builds
using the "@" prefix to silence builds is often great.
sometimes it can be annoying, e.g. when running automated builds on remote server where we don't have direct access to (think: continuous integration).
    
this patch uses the logic from autotools silent builds, which can be disabled when run as 

    make V=1

(`V=1` is used by autotools; CMake uses `VERBOSE=1`)

# reproducible builds
in Debian we would like to make sure that building the source code multiple times, gives the same results **bit for bit**.
This obviously won't work if the resulting binaries include things like the current date (at time of building).
Therefore we would like to include a patch that allows overriding of the current build time from the cmdline.

See also https://reproducible-builds.org/