### PR TITLE
Projucer Xcode exporter "keep custom targets" and AUv3/Standalone minimum SDK

### DIFF
--- a/extras/Projucer/Source/Project Saving/jucer_ProjectExport_XCode.h
+++ b/extras/Projucer/Source/Project Saving/jucer_ProjectExport_XCode.h
@@ -30,6 +30,7 @@ namespace
     const char* const osxVersionDefault         = "default";
     const int oldestSDKVersion  = 5;
     const int currentSDKVersion = 12;
+    const int minimumAUv3SDKVersion = 11;
 
     const char* const osxArch_Default           = "default";
     const char* const osxArch_Native            = "Native";
@@ -968,14 +969,17 @@ public:
 
                 // if the user doesn't set it, then use the last known version that works well with JUCE
                 String deploymentTarget = "10.11";
-
-                for (int ver = oldestSDKVersion; ver <= currentSDKVersion; ++ver)
+                String sdkTarget = "10.11";
+                int oldestAllowedSDKVersion = (type == AudioUnitv3PlugIn || type == StandalonePlugIn) ? minimumAUv3SDKVersion : oldestSDKVersion;
+                
+                for (int ver = oldestAllowedSDKVersion; ver <= currentSDKVersion; ++ver)
                 {
-                    if (sdk == getSDKName (ver))         s.add ("SDKROOT = macosx10." + String (ver));
+                    if (sdk == getSDKName (ver))         sdkTarget = "10." + String (ver);
                     if (sdkCompat == getSDKName (ver))   deploymentTarget = "10." + String (ver);
                 }
 
                 s.add ("MACOSX_DEPLOYMENT_TARGET = " + deploymentTarget);
+                s.add ("SDKROOT = macosx" + sdkTarget);
 
                 s.add ("MACOSX_DEPLOYMENT_TARGET_ppc = 10.4");
                 s.add ("SDKROOT_ppc = macosx10.5");

--- a/extras/Projucer/Source/Project Saving/jucer_ProjectExport_XCode.h
+++ b/extras/Projucer/Source/Project Saving/jucer_ProjectExport_XCode.h
@@ -205,8 +205,8 @@ public:
                    "string (for example, \"S7B6T5XJ2Q\") that describes the distribution certificate Apple issued to you. "
                    "You can find this string in the OS X app Keychain Access under \"Certificates\".");
         
-        props.add (new BooleanPropertyComponent (getSetting ("KeepCustomXcodeTargets"), "Keep custom Xcode targets", "Enabled"),
-                   "Enable this to keep any Xcode targets you have created yourself, e.g. for debugging or to launch a plug-in in various hosts. If disabled, all targets are replaced by a default set.");
+        props.add (new BooleanPropertyComponent (getSetting ("keepCustomXcodeSchemes"), "Keep custom Xcode schemes", "Enabled"),
+                   "Enable this to keep any Xcode schemes you have created for debugging or running, e.g. to launch a plug-in in various hosts. If disabled, all schemes are replaced by a default set.");
     }
 
     bool launchProject() override
@@ -2439,7 +2439,7 @@ private:
     //==============================================================================
     void removeMismatchedXcuserdata() const
     {
-        if (settings ["KeepCustomXcodeTargets"])
+        if (settings ["keepCustomXcodeSchemes"])
             return;
         
         File xcuserdata = getProjectBundle().getChildFile ("xcuserdata");

--- a/extras/Projucer/Source/Project Saving/jucer_ProjectExport_XCode.h
+++ b/extras/Projucer/Source/Project Saving/jucer_ProjectExport_XCode.h
@@ -969,17 +969,16 @@ public:
 
                 // if the user doesn't set it, then use the last known version that works well with JUCE
                 String deploymentTarget = "10.11";
-                String sdkTarget = "10.11";
+
                 int oldestAllowedSDKVersion = (type == AudioUnitv3PlugIn || type == StandalonePlugIn) ? minimumAUv3SDKVersion : oldestSDKVersion;
                 
                 for (int ver = oldestAllowedSDKVersion; ver <= currentSDKVersion; ++ver)
                 {
-                    if (sdk == getSDKName (ver))         sdkTarget = "10." + String (ver);
+                    if (sdk == getSDKName (ver))         s.add ("SDKROOT = macosx10." + String (ver));
                     if (sdkCompat == getSDKName (ver))   deploymentTarget = "10." + String (ver);
                 }
 
                 s.add ("MACOSX_DEPLOYMENT_TARGET = " + deploymentTarget);
-                s.add ("SDKROOT = macosx" + sdkTarget);
 
                 s.add ("MACOSX_DEPLOYMENT_TARGET_ppc = 10.4");
                 s.add ("SDKROOT_ppc = macosx10.5");

--- a/extras/Projucer/Source/Project Saving/jucer_ProjectExport_XCode.h
+++ b/extras/Projucer/Source/Project Saving/jucer_ProjectExport_XCode.h
@@ -203,6 +203,9 @@ public:
                    "The Development Team ID to be used for setting up code-signing your iOS app. This is a ten-character "
                    "string (for example, \"S7B6T5XJ2Q\") that describes the distribution certificate Apple issued to you. "
                    "You can find this string in the OS X app Keychain Access under \"Certificates\".");
+        
+        props.add (new BooleanPropertyComponent (getSetting ("KeepCustomXcodeTargets"), "Keep custom Xcode targets", "Enabled"),
+                   "Enable this to keep any Xcode targets you have created yourself, e.g. for debugging or to launch a plug-in in various hosts. If disabled, all targets are replaced by a default set.");
     }
 
     bool launchProject() override
@@ -2432,6 +2435,9 @@ private:
     //==============================================================================
     void removeMismatchedXcuserdata() const
     {
+        if (settings ["KeepCustomXcodeTargets"])
+            return;
+        
         File xcuserdata = getProjectBundle().getChildFile ("xcuserdata");
 
         if (! xcuserdata.exists())


### PR DESCRIPTION
1. Added a new boolean property labelled "Keep custom Xcode schemes" to the Projucer which keeps existing schemes with custom debugger settings or launch executables for plugin development.

2. AUv3 and stand-alone plug-in targets are automatically set upon export to use the Mac OS 10.11 SDK if an older SDK has been set for other targets.