### PR TITLE
Improve capability to check whether a socket is connected locally

### DIFF
--- a/modules/juce_core/network/juce_Socket.h
+++ b/modules/juce_core/network/juce_Socket.h
@@ -182,7 +182,7 @@ private:
     //==============================================================================
     String hostName;
     int volatile portNumber, handle;
-    bool connected, isListener;
+    bool connected, isListener, isLocalConnection;
     mutable CriticalSection readLock;
 
     StreamingSocket (const String& hostname, int portNumber, int handle);


### PR DESCRIPTION
Current check for if a socket is connected locally is (hostname == "127.0.0.1"). This is not complete as we could have connected to any local IP address, local hostname or "localhost" as well.

This pull request checks the ip address we connected to (regardless of how we got there) against all local IP addresses.

Also it adds an internal function which retrieves the IPv4 or IPv6 (future proof) string from the sockaddr struct.
