### PR TITLE
Added font kerning and typeface style support to ProJucer

### DIFF
--- a/extras/Projucer/Source/ComponentEditor/components/jucer_LabelHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_LabelHandler.h
@@ -80,11 +80,7 @@ public:
         font.setBold (xml.getBoolAttribute ("bold", false));
         font.setItalic (xml.getBoolAttribute ("italic", false));
         font.setExtraKerningFactor ((float) xml.getDoubleAttribute ("kerning", 0.0));
-        String style = xml.getStringAttribute ("typefaceStyle", "Regular");
-        if (font.getAvailableStyles().contains (style))
-        {
-            font.setTypefaceStyle (style);
-        }
+        font.setTypefaceStyle (xml.getStringAttribute ("typefaceStyle", "Regular"));
         l->setFont (font);
 
         l->getProperties().set ("typefaceName", xml.getStringAttribute ("fontname", FontPropertyComponent::getDefaultFont()));

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementText.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementText.h
@@ -439,7 +439,7 @@ private:
               element (e)
         {
             element->getDocument()->addChangeListener (this);
-            updateStylesList (element->getFont());
+            updateStylesList (element->getTypefaceName());
         }
         
         ~FontTypefaceStyleProperty()
@@ -447,7 +447,7 @@ private:
             element->getDocument()->removeChangeListener (this);
         }
         
-        void updateStylesList (const Font& newFont)
+        void updateStylesList (const String& name)
         {
             if (getNumChildComponents())
             {
@@ -457,7 +457,7 @@ private:
             }
             
             choices.clear();
-            choices.addArray (newFont.getAvailableStyles());
+            choices.addArray (Font::findAllTypefaceStyles(name));
             refresh();
         }
         
@@ -475,7 +475,7 @@ private:
         
         void changeListenerCallback (ChangeBroadcaster*)
         {
-            updateStylesList (element->getFont());
+            updateStylesList (element->getTypefaceName());
         }
         
     private:

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementText.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementText.h
@@ -140,11 +140,7 @@ public:
             font.setItalic (xml.getBoolAttribute ("italic", false));
             font.setExtraKerningFactor ((float) xml.getDoubleAttribute ("kerning", 0.0));
             justification = Justification (xml.getIntAttribute ("justification", Justification::centred));
-            String style = xml.getStringAttribute ("typefaceStyle", "Regular");
-            if (font.getAvailableStyles().contains (style))
-            {
-                font.setTypefaceStyle (style);
-            }
+            font.setTypefaceStyle (xml.getStringAttribute ("typefaceStyle", "Regular"));
             
             return true;
         }

--- a/extras/Projucer/Source/ComponentEditor/properties/jucer_FontPropertyComponent.h
+++ b/extras/Projucer/Source/ComponentEditor/properties/jucer_FontPropertyComponent.h
@@ -85,7 +85,7 @@ public:
         if (typefaceName == getDefaultSerif()) return Font (Font::getDefaultSerifFontName(), font.getHeight(), font.getStyleFlags());
         if (typefaceName == getDefaultMono())  return Font (Font::getDefaultMonospacedFontName(), font.getHeight(), font.getStyleFlags());
 
-        return Font (typefaceName, font.getHeight(), font.getStyleFlags());
+        return Font (typefaceName, font.getHeight(), font.getStyleFlags()).withExtraKerningFactor(font.getExtraKerningFactor());
     }
 
     static String getTypefaceNameCode (const String& typefaceName)
@@ -109,12 +109,18 @@ public:
 
     static String getCompleteFontCode (const Font& font, const String& typefaceName)
     {
-        return "Font ("
-            + getTypefaceNameCode (typefaceName)
-            + CodeHelpers::floatLiteral (font.getHeight(), 2)
-            + ", "
-            + getFontStyleCode (font)
-            + ")";
+        String s;
+        s << "Font ("
+          << getTypefaceNameCode (typefaceName)
+          << CodeHelpers::floatLiteral (font.getHeight(), 2)
+          << ", "
+          << getFontStyleCode (font);
+        if (font.getExtraKerningFactor() != 0)
+        {
+            s << ".withExtraKerningFactor (" << CodeHelpers::floatLiteral (font.getExtraKerningFactor(), 3) << ")";
+        }
+        s << ")";
+        return s;
     }
 };
 

--- a/extras/Projucer/Source/ComponentEditor/properties/jucer_FontPropertyComponent.h
+++ b/extras/Projucer/Source/ComponentEditor/properties/jucer_FontPropertyComponent.h
@@ -85,7 +85,12 @@ public:
         if (typefaceName == getDefaultSerif()) return Font (Font::getDefaultSerifFontName(), font.getHeight(), font.getStyleFlags());
         if (typefaceName == getDefaultMono())  return Font (Font::getDefaultMonospacedFontName(), font.getHeight(), font.getStyleFlags());
 
-        return Font (typefaceName, font.getHeight(), font.getStyleFlags()).withExtraKerningFactor(font.getExtraKerningFactor());
+        Font f = Font (typefaceName, font.getHeight(), font.getStyleFlags()).withExtraKerningFactor (font.getExtraKerningFactor());
+        if (f.getAvailableStyles().contains (font.getTypefaceStyle()))
+        {
+            f.setTypefaceStyle (font.getTypefaceStyle());
+        }
+        return f;
     }
 
     static String getTypefaceNameCode (const String& typefaceName)
@@ -116,6 +121,10 @@ public:
           << ", "
           << getFontStyleCode (font)
           << ")";
+        if (font.getTypefaceStyle() != "Regular")
+        {
+            s << ".withTypefaceStyle (" << CodeHelpers::stringLiteral (font.getTypefaceStyle()) << ")";
+        }
         if (font.getExtraKerningFactor() != 0)
         {
             s << ".withExtraKerningFactor (" << CodeHelpers::floatLiteral (font.getExtraKerningFactor(), 3) << ")";

--- a/extras/Projucer/Source/ComponentEditor/properties/jucer_FontPropertyComponent.h
+++ b/extras/Projucer/Source/ComponentEditor/properties/jucer_FontPropertyComponent.h
@@ -114,12 +114,12 @@ public:
           << getTypefaceNameCode (typefaceName)
           << CodeHelpers::floatLiteral (font.getHeight(), 2)
           << ", "
-          << getFontStyleCode (font);
+          << getFontStyleCode (font)
+          << ")";
         if (font.getExtraKerningFactor() != 0)
         {
             s << ".withExtraKerningFactor (" << CodeHelpers::floatLiteral (font.getExtraKerningFactor(), 3) << ")";
         }
-        s << ")";
         return s;
     }
 };


### PR DESCRIPTION
In order to properly use fonts in ProJucer, by basing yourself on existing Photoshop/Illustrator designs, it's important to be able able to set the exact kerning and to select a specific typeface style. These changes provide this for the Label component and the Text paint element.