### PR TITLE
Fixed assert in ModuleDescription::getHeader() when moduleFolder is i…

### DIFF
--- a/extras/Projucer/Source/Project/jucer_Module.cpp
+++ b/extras/Projucer/Source/Project/jucer_Module.cpp
@@ -94,12 +94,14 @@ File ModuleDescription::getHeader() const
 {
     const char* extensions[] = { ".h", ".hpp", ".hxx" };
 
-    for (int i = 0; i < numElementsInArray (extensions); ++i)
-    {
-        File header (moduleFolder.getChildFile (moduleFolder.getFileName() + extensions[i]));
+    if (moduleFolder != File()) {
+        for (int i = 0; i < numElementsInArray (extensions); ++i)
+        {
+            File header (moduleFolder.getChildFile (moduleFolder.getFileName() + extensions[i]));
 
-        if (header.existsAsFile())
-            return header;
+            if (header.existsAsFile())
+                return header;
+        }
     }
 
     return File();


### PR DESCRIPTION
In ModuleDescription::getHeader() accessing a child file of the invalid moduleFolder triggers an assert.
It can be observed, when a project is opened and the location of modules has changed.