### PR TITLE
Add getCpuModel function and getCpuSpeedInMegaherz on Android

### DIFF
--- a/examples/Demo/Source/Demos/SystemInfoDemo.cpp
+++ b/examples/Demo/Source/Demos/SystemInfoDemo.cpp
@@ -125,6 +125,7 @@ static String getAllSystemInfo()
       << "Number of CPUs:  " << SystemStats::getNumCpus() << newLine
       << "Memory size:     " << SystemStats::getMemorySizeInMegabytes() << " MB" << newLine
       << "CPU vendor:      " << SystemStats::getCpuVendor() << newLine
+      << "CPU model:       " << SystemStats::getCpuModel() << newLine
       << "CPU speed:       " << SystemStats::getCpuSpeedInMegaherz() << " MHz" << newLine
       << "CPU has MMX:     " << (SystemStats::hasMMX()    ? "yes" : "no") << newLine
       << "CPU has SSE:     " << (SystemStats::hasSSE()    ? "yes" : "no") << newLine

--- a/modules/juce_core/native/juce_linux_SystemStats.cpp
+++ b/modules/juce_core/native/juce_linux_SystemStats.cpp
@@ -90,6 +90,11 @@ String SystemStats::getCpuVendor()
     return v;
 }
 
+String SystemStats::getCpuModel()
+{
+    return LinuxStatsHelpers::getCpuInfo ("model name");
+}
+
 int SystemStats::getCpuSpeedInMegaherz()
 {
     return roundToInt (LinuxStatsHelpers::getCpuInfo ("cpu MHz").getFloatValue());

--- a/modules/juce_core/native/juce_mac_SystemStats.mm
+++ b/modules/juce_core/native/juce_mac_SystemStats.mm
@@ -176,6 +176,17 @@ String SystemStats::getCpuVendor()
    #endif
 }
 
+String SystemStats::getCpuModel()
+{
+    char name[0x40];
+    size_t size = sizeof(name);
+
+    if (sysctlbyname("machdep.cpu.brand_string", &name, &size, nullptr, 0) < 0)
+        return String();
+
+    return String(name);
+}
+
 int SystemStats::getCpuSpeedInMegaherz()
 {
     uint64 speedHz = 0;

--- a/modules/juce_core/native/juce_win32_SystemStats.cpp
+++ b/modules/juce_core/native/juce_win32_SystemStats.cpp
@@ -79,6 +79,30 @@ String SystemStats::getCpuVendor()
     return String (v, 12);
 }
 
+String SystemStats::getCpuModel()
+{
+    char name[0x40] = {0};
+
+    int info[4] = { 0 };
+    callCPUID (info, 0x80000000);
+
+    const int numExtIds = info[0];
+    // This indicates Brand String is unsupported
+    if (numExtIds < 0x80000004)
+        return String();
+
+    callCPUID (info, 0x80000002);
+    memcpy(name, info, sizeof(info));
+
+    callCPUID (info, 0x80000003);
+    memcpy(name + 16, info, sizeof(info));
+
+    callCPUID (info, 0x80000004);
+    memcpy(name + 32, info, sizeof(info));
+
+    return String(name).trim();
+}
+
 //==============================================================================
 void CPUInformation::initialise() noexcept
 {

--- a/modules/juce_core/system/juce_SystemStats.h
+++ b/modules/juce_core/system/juce_SystemStats.h
@@ -154,6 +154,11 @@ public:
     */
     static String getCpuVendor();
 
+    /** Returns a string to indicate the CPU model.
+     Might not be known on some systems.
+     */
+    static String getCpuModel();
+
     static bool hasMMX() noexcept;    /**< Returns true if Intel MMX instructions are available. */
     static bool has3DNow() noexcept;  /**< Returns true if AMD 3DNOW instructions are available. */
     static bool hasSSE() noexcept;    /**< Returns true if Intel SSE instructions are available. */


### PR DESCRIPTION
1. JUCE learned to get CPU brand string (e.g. Intel(R) Xeon(R) CPU E5-1650 v2 @ 3.50GHz) on OSX, Windows and Linux

This was tested on OSX 10.12, Windows 10 and CentOS 7

2. JUCE learned to get CPU type from "Hardware:" field in /proc/cpuinfo on Android

This was tested on OnePlus 3T

3. JUCE learned to retrieve the CPU speed on Android from a /sys/devices file

This was tested on OnePlus 3T. OnePlus 3T has 4 cores with 2 different clock speeds so it chooses the highest clock speed of the avaialble cores.