### PR TITLE
Add a line spacing feature to CodeEditorComponent, and a corresponding preference in Projucer.

### DIFF
--- a/extras/Projucer/Source/Application/jucer_AppearanceSettings.cpp
+++ b/extras/Projucer/Source/Application/jucer_AppearanceSettings.cpp
@@ -268,7 +268,7 @@ Value AppearanceSettings::getCodeFontValue()
 
 float AppearanceSettings::getLineSpacing() const
 {
-    const String lineSpacingString(settings[Ids::lineSpacing].toString());
+    const String lineSpacingString (settings[Ids::lineSpacing].toString());
 
     if (lineSpacingString.isEmpty())
         return getDefaultLineSpacing();

--- a/extras/Projucer/Source/Application/jucer_AppearanceSettings.cpp
+++ b/extras/Projucer/Source/Application/jucer_AppearanceSettings.cpp
@@ -234,7 +234,7 @@ void AppearanceSettings::applyToCodeEditor (CodeEditorComponent& editor) const
 
     editor.setColourScheme (cs);
     editor.setFont (getCodeFont());
-    editor.setLineSpacing(getLineSpacing());
+    editor.setLineSpacing (getLineSpacing());
 
     for (int i = 0; i < AppearanceColours::numColours; ++i)
     {
@@ -278,7 +278,7 @@ float AppearanceSettings::getLineSpacing() const
 
 Value AppearanceSettings::getLineSpacingValue()
 {
-    return settings.getPropertyAsValue(Ids::lineSpacing, nullptr);
+    return settings.getPropertyAsValue (Ids::lineSpacing, nullptr);
 }
 
 Value AppearanceSettings::getColourValue (const String& colourName)

--- a/extras/Projucer/Source/Application/jucer_AppearanceSettings.cpp
+++ b/extras/Projucer/Source/Application/jucer_AppearanceSettings.cpp
@@ -178,6 +178,11 @@ Font AppearanceSettings::getDefaultCodeFont()
     return Font (Font::getDefaultMonospacedFontName(), Font::getDefaultStyle(), 13.0f);
 }
 
+float AppearanceSettings::getDefaultLineSpacing()
+{
+    return 1.0f;
+}
+
 StringArray AppearanceSettings::getColourNames() const
 {
     StringArray s;
@@ -229,6 +234,7 @@ void AppearanceSettings::applyToCodeEditor (CodeEditorComponent& editor) const
 
     editor.setColourScheme (cs);
     editor.setFont (getCodeFont());
+    editor.setLineSpacing(getLineSpacing());
 
     for (int i = 0; i < AppearanceColours::numColours; ++i)
     {
@@ -258,6 +264,21 @@ Font AppearanceSettings::getCodeFont() const
 Value AppearanceSettings::getCodeFontValue()
 {
     return settings.getPropertyAsValue (Ids::font, nullptr);
+}
+
+float AppearanceSettings::getLineSpacing() const
+{
+    const String lineSpacingString(settings[Ids::lineSpacing].toString());
+
+    if (lineSpacingString.isEmpty())
+        return getDefaultLineSpacing();
+
+    return lineSpacingString.getFloatValue();
+}
+
+Value AppearanceSettings::getLineSpacingValue()
+{
+    return settings.getPropertyAsValue(Ids::lineSpacing, nullptr);
 }
 
 Value AppearanceSettings::getColourValue (const String& colourName)

--- a/extras/Projucer/Source/Application/jucer_AppearanceSettings.h
+++ b/extras/Projucer/Source/Application/jucer_AppearanceSettings.h
@@ -44,6 +44,9 @@ public:
     Font getCodeFont() const;
     Value getCodeFontValue();
 
+    float getLineSpacing() const;
+    Value getLineSpacingValue();
+
     ValueTree settings;
 
     static File getSchemesFolder();
@@ -52,6 +55,7 @@ public:
     void selectPresetScheme (int index);
 
     static Font getDefaultCodeFont();
+    static float getDefaultLineSpacing();
 
     static void showGlobalPreferences (ScopedPointer<Component>& ownerPointer);
 

--- a/extras/Projucer/Source/Application/jucer_GlobalPreferences.cpp
+++ b/extras/Projucer/Source/Application/jucer_GlobalPreferences.cpp
@@ -196,7 +196,7 @@ struct AppearanceEditor
             props.add (FontSizeValueSource::createProperty ("Font Size", fontValue));
             
             Value lineSpacingValue (scheme.getLineSpacingValue());
-            props.add (LineSpacingValueSource::createProperty("Line Spacing", lineSpacingValue));
+            props.add (LineSpacingValueSource::createProperty ("Line Spacing", lineSpacingValue));
 
             const StringArray colourNames (scheme.getColourNames());
 

--- a/extras/Projucer/Source/Application/jucer_GlobalPreferences.cpp
+++ b/extras/Projucer/Source/Application/jucer_GlobalPreferences.cpp
@@ -195,7 +195,7 @@ struct AppearanceEditor
             props.add (FontNameValueSource::createProperty ("Code Editor Font", fontValue));
             props.add (FontSizeValueSource::createProperty ("Font Size", fontValue));
             
-            Value lineSpacingValue(scheme.getLineSpacingValue());
+            Value lineSpacingValue (scheme.getLineSpacingValue());
             props.add (LineSpacingValueSource::createProperty("Line Spacing", lineSpacingValue));
 
             const StringArray colourNames (scheme.getColourNames());
@@ -329,15 +329,15 @@ struct AppearanceEditor
             return sourceValue.toString();
         }
 
-        void setValue(const var& newValue) override
+        void setValue (const var& newValue) override
         {
             sourceValue = newValue.toString();
         }
 
-        static PropertyComponent* createProperty(const String& title, const Value& value)
+        static PropertyComponent* createProperty (const String& title, const Value& value)
         {
-            return new SliderPropertyComponent(Value(new LineSpacingValueSource(value)),
-                title, 1.0, 1.6, 0.1, 1.0);
+            return new SliderPropertyComponent (Value (new LineSpacingValueSource (value)),
+                                                title, 1.0, 1.6, 0.1, 1.0);
         }
     };
 };

--- a/extras/Projucer/Source/Application/jucer_GlobalPreferences.cpp
+++ b/extras/Projucer/Source/Application/jucer_GlobalPreferences.cpp
@@ -194,6 +194,9 @@ struct AppearanceEditor
             Value fontValue (scheme.getCodeFontValue());
             props.add (FontNameValueSource::createProperty ("Code Editor Font", fontValue));
             props.add (FontSizeValueSource::createProperty ("Font Size", fontValue));
+            
+            Value lineSpacingValue(scheme.getLineSpacingValue());
+            props.add (LineSpacingValueSource::createProperty("Line Spacing", lineSpacingValue));
 
             const StringArray colourNames (scheme.getColourNames());
 
@@ -313,6 +316,28 @@ struct AppearanceEditor
         {
             return new SliderPropertyComponent (Value (new FontSizeValueSource (value)),
                                                 title, 5.0, 40.0, 0.1, 0.5);
+        }
+    };
+
+    //==============================================================================
+    struct LineSpacingValueSource : public ValueSourceFilter
+    {
+        LineSpacingValueSource(const Value& source) : ValueSourceFilter(source) {}
+
+        var getValue() const override
+        {
+            return sourceValue.toString();
+        }
+
+        void setValue(const var& newValue) override
+        {
+            sourceValue = newValue.toString();
+        }
+
+        static PropertyComponent* createProperty(const String& title, const Value& value)
+        {
+            return new SliderPropertyComponent(Value(new LineSpacingValueSource(value)),
+                title, 1.0, 1.6, 0.1, 1.0);
         }
     };
 };

--- a/extras/Projucer/Source/Utility/jucer_PresetIDs.h
+++ b/extras/Projucer/Source/Utility/jucer_PresetIDs.h
@@ -228,6 +228,7 @@ namespace Ids
     DECLARE_ID (classDecl);
     DECLARE_ID (initialisers);
     DECLARE_ID (destructors);
+    DECLARE_ID (lineSpacing);
 
     const Identifier ID ("id");
     const Identifier ID_uppercase ("ID");

--- a/modules/juce_gui_extra/code_editor/juce_CodeEditorComponent.cpp
+++ b/modules/juce_gui_extra/code_editor/juce_CodeEditorComponent.cpp
@@ -415,7 +415,7 @@ void CodeEditorComponent::setLineSpacing(float factor)
     else
         lineSpacing = 1.0f;
 
-    lineHeight = roundToInt(font.getHeight() * lineSpacing);
+    lineHeight = roundToInt (font.getHeight() * lineSpacing);
 }
 
 bool CodeEditorComponent::isTextInputActive() const

--- a/modules/juce_gui_extra/code_editor/juce_CodeEditorComponent.cpp
+++ b/modules/juce_gui_extra/code_editor/juce_CodeEditorComponent.cpp
@@ -336,6 +336,7 @@ CodeEditorComponent::CodeEditorComponent (CodeDocument& doc, CodeTokeniser* cons
       firstLineOnScreen (0),
       spacesPerTab (4),
       lineHeight (0),
+      lineSpacing (1.0f),
       linesOnScreen (0),
       columnsOnScreen (0),
       scrollbarThickness (16),
@@ -405,6 +406,16 @@ void CodeEditorComponent::loadContent (const String& newContent)
     selectionStart.setPosition (0);
     selectionEnd.setPosition (0);
     scrollToLine (0);
+}
+
+void CodeEditorComponent::setLineSpacing(float factor)
+{
+    if (factor >= 0.2f && factor <= 3.0f)
+        lineSpacing = factor;
+    else
+        lineSpacing = 1.0f;
+
+    lineHeight = roundToInt(font.getHeight() * lineSpacing);
 }
 
 bool CodeEditorComponent::isTextInputActive() const
@@ -1510,7 +1521,7 @@ void CodeEditorComponent::setFont (const Font& newFont)
 {
     font = newFont;
     charWidth = font.getStringWidthFloat ("0");
-    lineHeight = roundToInt (font.getHeight());
+    lineHeight = roundToInt (font.getHeight() * lineSpacing);
     resized();
 }
 

--- a/modules/juce_gui_extra/code_editor/juce_CodeEditorComponent.h
+++ b/modules/juce_gui_extra/code_editor/juce_CodeEditorComponent.h
@@ -71,6 +71,12 @@ public:
     /** Returns the height of a line of text, in pixels. */
     int getLineHeight() const noexcept                          { return lineHeight; }
 
+    /** Returns the line spacing factor */
+    float getLineSpacing() const noexcept                          { return lineSpacing; }
+
+    /** Set the line spacing factor. Valid values between 0.2f and 3.0f */
+    void setLineSpacing(float factor);
+
     /** Returns the number of whole lines visible on the screen,
         This doesn't include a cut-off line that might be visible at the bottom if the
         component's height isn't an exact multiple of the line-height.
@@ -364,6 +370,7 @@ private:
     Font font;
     int firstLineOnScreen, spacesPerTab;
     float charWidth;
+    float lineSpacing;
     int lineHeight, linesOnScreen, columnsOnScreen;
     int scrollbarThickness, columnToTryToMaintain;
     bool readOnly, useSpacesForTabs, showLineNumbers, shouldFollowDocumentChanges;

--- a/modules/juce_gui_extra/code_editor/juce_CodeEditorComponent.h
+++ b/modules/juce_gui_extra/code_editor/juce_CodeEditorComponent.h
@@ -72,10 +72,10 @@ public:
     int getLineHeight() const noexcept                          { return lineHeight; }
 
     /** Returns the line spacing factor */
-    float getLineSpacing() const noexcept                          { return lineSpacing; }
+    float getLineSpacing() const noexcept                       { return lineSpacing; }
 
     /** Set the line spacing factor. Valid values between 0.2f and 3.0f */
-    void setLineSpacing(float factor);
+    void setLineSpacing (float factor);
 
     /** Returns the number of whole lines visible on the screen,
         This doesn't include a cut-off line that might be visible at the bottom if the


### PR DESCRIPTION
A slider preference in Projucer that adjusts the line spacing in CodeEditorComponent.