### PR TITLE
Get the number of physical cores

### DIFF
--- a/examples/Demo/Source/Demos/SystemInfoDemo.cpp
+++ b/examples/Demo/Source/Demos/SystemInfoDemo.cpp
@@ -123,6 +123,7 @@ static String getAllSystemInfo()
 
     systemInfo
       << "Number of CPUs:  " << SystemStats::getNumCpus() << newLine
+      << "Physical CPUs:   " << SystemStats::getNumPhysicalCpus() << newLine
       << "Memory size:     " << SystemStats::getMemorySizeInMegabytes() << " MB" << newLine
       << "CPU vendor:      " << SystemStats::getCpuVendor() << newLine
       << "CPU model:       " << SystemStats::getCpuModel() << newLine

--- a/modules/juce_core/native/juce_android_SystemStats.cpp
+++ b/modules/juce_core/native/juce_android_SystemStats.cpp
@@ -283,6 +283,7 @@ String SystemStats::getDisplayLanguage() { return getUserLanguage() + "-" + getU
 void CPUInformation::initialise() noexcept
 {
     numCpus = jmax ((int) 1, (int) sysconf (_SC_NPROCESSORS_ONLN));
+    numPhysicalCpus = numCpus;
 }
 
 //==============================================================================

--- a/modules/juce_core/native/juce_linux_SystemStats.cpp
+++ b/modules/juce_core/native/juce_linux_SystemStats.cpp
@@ -154,6 +154,13 @@ void CPUInformation::initialise() noexcept
     hasAVX2  = flags.contains ("avx2");
 
     numCpus = getCpuInfo ("processor").getIntValue() + 1;
+
+    // Assume CPUs in all sockets have the same number of cores
+    numPhysicalCpus = getCpuInfo ("cpu cores").getIntValue() *
+                     (getCpuInfo ("physical id").getIntValue() + 1);
+
+    if (numPhysicalCpus == 0)
+        numPhysicalCpus = numCpus;
 }
 
 //==============================================================================

--- a/modules/juce_core/native/juce_mac_SystemStats.mm
+++ b/modules/juce_core/native/juce_mac_SystemStats.mm
@@ -92,6 +92,13 @@ void CPUInformation::initialise() noexcept
    #endif
 
     numCpus = (int) [[NSProcessInfo processInfo] activeProcessorCount];
+
+    unsigned int numPhys;
+    size_t len = sizeof(numPhys);
+    if (sysctlbyname ("hw.physicalcpu", &numPhys, &len, nullptr, 0) >= 0)
+        numPhysicalCpus = numPhys;
+    else
+        numPhysicalCpus = numCpus;
 }
 
 //==============================================================================

--- a/modules/juce_core/system/juce_SystemStats.cpp
+++ b/modules/juce_core/system/juce_SystemStats.cpp
@@ -68,7 +68,7 @@ String SystemStats::getJUCEVersion()
 struct CPUInformation
 {
     CPUInformation() noexcept
-        : numCpus (0), hasMMX (false), hasSSE (false),
+        : numCpus (0), numPhysicalCpus(0), hasMMX (false), hasSSE (false),
           hasSSE2 (false), hasSSE3 (false), has3DNow (false),
           hasSSSE3 (false), hasSSE41 (false), hasSSE42 (false),
           hasAVX (false), hasAVX2 (false)
@@ -79,6 +79,7 @@ struct CPUInformation
     void initialise() noexcept;
 
     int numCpus;
+    int numPhysicalCpus;
     bool hasMMX, hasSSE, hasSSE2, hasSSE3, has3DNow, hasSSSE3, hasSSE41, hasSSE42, hasAVX, hasAVX2;
 };
 
@@ -89,6 +90,7 @@ static const CPUInformation& getCPUInformation() noexcept
 }
 
 int SystemStats::getNumCpus() noexcept        { return getCPUInformation().numCpus; }
+int SystemStats::getNumPhysicalCpus() noexcept { return getCPUInformation().numPhysicalCpus; }
 bool SystemStats::hasMMX() noexcept           { return getCPUInformation().hasMMX; }
 bool SystemStats::has3DNow() noexcept         { return getCPUInformation().has3DNow; }
 bool SystemStats::hasSSE() noexcept           { return getCPUInformation().hasSSE; }

--- a/modules/juce_core/system/juce_SystemStats.h
+++ b/modules/juce_core/system/juce_SystemStats.h
@@ -143,6 +143,13 @@ public:
     /** Returns the number of CPU cores. */
     static int getNumCpus() noexcept;
 
+    /** Returns the number of physical CPU cores. This ignores hyperthreading.
+        If it cannot find the correct number it is assumed to be equal to 
+        getNumCpus().
+        @see getNumCpus()
+     */
+    static int getNumPhysicalCpus() noexcept;
+
     /** Returns the approximate CPU speed.
         @returns    the speed in megahertz, e.g. 1500, 2500, 32000 (depending on
                     what year you're reading this...)


### PR DESCRIPTION
* This ignores hyperthreading
* Tested on OSX 10.12, Windows 10 (should work in XP and up), CentOS 7 (should work on all Intel linux)
* Deficiencies:
** Returns numPhysicalCpus = numCpus on Android (I have no hyperthreading Android device to test)
** Untested on AMD/ARM linux