### PR TITLE
Extended AudioPlayHead::FrameRateType to support a 60 fps flag.

### DIFF
--- a/modules/juce_audio_basics/audio_play_head/juce_AudioPlayHead.h
+++ b/modules/juce_audio_basics/audio_play_head/juce_AudioPlayHead.h
@@ -54,6 +54,8 @@ public:
         fps30           = 3,
         fps2997drop     = 4,
         fps30drop       = 5,
+        fps60           = 6,
+        fps60drop       = 7,
         fpsUnknown      = 99
     };
 

--- a/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
@@ -208,6 +208,16 @@ static void toProcessContext (Vst::ProcessContext& context, AudioPlayHead* playH
             case AudioPlayHead::fps25: context.frameRate.framesPerSecond = 25; break;
             case AudioPlayHead::fps30: context.frameRate.framesPerSecond = 30; break;
 
+            case AudioPlayHead::fps60:
+            case AudioPlayHead::fps60drop:
+            {
+                context.frameRate.framesPerSecond = 60;
+
+                if (position.frameRate == AudioPlayHead::fps60drop)
+                    context.frameRate.flags = FrameRate::kDropRate;
+            }
+            break;
+
             case AudioPlayHead::fps2997:
             case AudioPlayHead::fps2997drop:
             case AudioPlayHead::fps30drop:

--- a/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.cpp
@@ -1697,12 +1697,15 @@ private:
 
                     switch (position.frameRate)
                     {
-                        case AudioPlayHead::fps24:       setHostTimeFrameRate (0, 24.0,  position.timeInSeconds); break;
-                        case AudioPlayHead::fps25:       setHostTimeFrameRate (1, 25.0,  position.timeInSeconds); break;
-                        case AudioPlayHead::fps2997:     setHostTimeFrameRate (2, 30.0 * 1000.0 / 1001.0, position.timeInSeconds); break;
-                        case AudioPlayHead::fps30:       setHostTimeFrameRate (3, 30.0,  position.timeInSeconds); break;
-                        case AudioPlayHead::fps2997drop: setHostTimeFrameRate (4, 30.0 * 1000.0 / 1001.0, position.timeInSeconds); break;
-                        case AudioPlayHead::fps30drop:   setHostTimeFrameRate (5, 30.0 * 1000.0 / 1001.0, position.timeInSeconds); break;
+                        case AudioPlayHead::fps24:       setHostTimeFrameRate (vstSmpteRateFps24, 24.0, position.timeInSeconds); break;
+                        case AudioPlayHead::fps25:       setHostTimeFrameRate (vstSmpteRateFps25, 25.0, position.timeInSeconds); break;
+                        case AudioPlayHead::fps30:       setHostTimeFrameRate (vstSmpteRateFps30, 30.0, position.timeInSeconds); break;
+                        case AudioPlayHead::fps60:       setHostTimeFrameRate (vstSmpteRateFps60, 60.0, position.timeInSeconds); break;
+
+                        case AudioPlayHead::fps2997:     setHostTimeFrameRateDrop (vstSmpteRateFps2997,     30.0, position.timeInSeconds); break;
+                        case AudioPlayHead::fps2997drop: setHostTimeFrameRateDrop (vstSmpteRateFps2997drop, 30.0, position.timeInSeconds); break;
+                        case AudioPlayHead::fps30drop:   setHostTimeFrameRateDrop (vstSmpteRateFps30drop,   30.0, position.timeInSeconds); break;
+                        case AudioPlayHead::fps60drop:   setHostTimeFrameRateDrop (vstSmpteRateFps599,      60.0, position.timeInSeconds); break;
                         default: break;
                     }
 
@@ -1789,6 +1792,11 @@ private:
         vstHostTime.flags |= vstTimingInfoFlagSmpteValid;
         vstHostTime.smpteRate       = (int32) frameRateIndex;
         vstHostTime.smpteOffset     = (int32) (currentTime * 80.0 * frameRate + 0.5);
+    }
+
+    void setHostTimeFrameRateDrop (long frameRateIndex, double frameRate, double currentTime) noexcept
+    {
+        setHostTimeFrameRate (frameRateIndex, frameRate * 1000.0 / 1001.0, currentTime);
     }
 
     bool restoreProgramSettings (const fxProgram* const prog)


### PR DESCRIPTION
The intent is to allow a host to specify a modern frame-rate, which VST2 and VST3 support.